### PR TITLE
OPSEXP-1855 Fix activemq service selector construction

### DIFF
--- a/charts/activemq/Chart.yaml
+++ b/charts/activemq/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 name: activemq
 sources:
   - https://github.com/Alfresco/alfresco-helm-charts
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - name: alfresco-common
     version: 1.0.0

--- a/charts/activemq/README.md
+++ b/charts/activemq/README.md
@@ -1,6 +1,6 @@
 # activemq
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: 5.17.1](https://img.shields.io/badge/AppVersion-5.17.1-informational?style=flat-square)
+![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 5.17.1](https://img.shields.io/badge/AppVersion-5.17.1-informational?style=flat-square)
 
 A Helm chart providing a basic Apache ActiveMQ deployment required to evaluate ACS (not meant to be used in production).
 

--- a/charts/activemq/templates/svc-activemq-broker.yaml
+++ b/charts/activemq/templates/svc-activemq-broker.yaml
@@ -20,5 +20,4 @@ spec:
     name: amqp
     protocol: TCP
   selector:
-    app: {{ template "activemq.fullname" . }}
-    release: {{ .Release.Name }}
+    {{- include "activemq.selectorLabels" . | nindent 4 }}

--- a/charts/activemq/templates/svc-activemq-web-console.yaml
+++ b/charts/activemq/templates/svc-activemq-web-console.yaml
@@ -12,5 +12,4 @@ spec:
     name: web-console
     protocol: TCP
   selector:
-    app: {{ template "activemq.fullname" . }}
-    release: {{ .Release.Name }}
+    {{- include "activemq.selectorLabels" . | nindent 4 }}

--- a/charts/activemq/tests/deployment-activemq_test.yaml
+++ b/charts/activemq/tests/deployment-activemq_test.yaml
@@ -1,5 +1,5 @@
 ---
-suite: test activemq persistence
+suite: test activemq deployment
 templates:
   - deployment-activemq.yaml
 tests:

--- a/charts/activemq/tests/pvc-activemq_test.yaml
+++ b/charts/activemq/tests/pvc-activemq_test.yaml
@@ -16,6 +16,7 @@ tests:
               sizeLimit: 20Gi
             name: data
         template: deployment-activemq.yaml
+
   - it: should render a deployment with set claim
     set:
       persistence:
@@ -27,6 +28,7 @@ tests:
             spec.template.spec.volumes[0].persistentVolumeClaim.claimName
           value: mysfsvolume
         template: deployment-activemq.yaml
+
   - it: should render a deployment with dynamic claim name
     set:
       persistence:
@@ -44,6 +46,7 @@ tests:
       - isNull:
           path: spec.storageClassName
         template: pvc-activemq.yaml
+
   - it: should render a deployment with provided storage class
     set:
       persistence:

--- a/charts/activemq/tests/svc-activemq_test.yaml
+++ b/charts/activemq/tests/svc-activemq_test.yaml
@@ -1,0 +1,20 @@
+---
+suite: test activemq services
+templates:
+  - svc-activemq-broker.yaml
+  - svc-activemq-web-console.yaml
+tests:
+  - it: should use the default service name
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: activemq
+        template: svc-activemq-broker.yaml
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: activemq
+        template: svc-activemq-web-console.yaml


### PR DESCRIPTION
Ref: OPSEXP-1855

was not using the same named template used to build pod metadata and service discovery was broken