### PR TITLE
OPSEXP-1855 Get rid of previous activemq.fullname template

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - name: common
     repository: >-

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-activemq.tpl
+++ b/charts/alfresco-common/templates/_helpers-activemq.tpl
@@ -1,11 +1,3 @@
-{{/*
-Create a default fully qualified name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "activemq.fullname" -}}
-{{- printf "%s-activemq" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 {{- define "activemq.env" -}}
 - name: ACTIVEMQ_URL
   value: $(BROKER_URL)


### PR DESCRIPTION
This can cause some weird behaviour since it's conflicting with https://github.com/Alfresco/alfresco-helm-charts/blob/main/charts/activemq/templates/_helpers.tpl#L13