### PR TITLE
OPSEXP-1881 KinD tests with latest 1.24 tag

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INSTALL_NAMESPACE: alfresco
+      TEST_ALL_CHARTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci-test-all') && 'true' || 'false' }}
+      TEST_ALL_CHARTS_ARG: ${{ contains(github.event.pull_request.labels.*.name, 'ci-test-all') && '--all' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -41,12 +43,12 @@ jobs:
         id: list-changed
         run: |
           changed=$(ct list-changed --config ct-lint.yaml)
-          if [[ -n "$changed" ]]; then
+          if [[ -n "$changed" || "$TEST_ALL_CHARTS" == "true" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct-lint.yaml
+        run: ct lint --config ct-lint.yaml $TEST_ALL_CHARTS_ARG
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.5.0
@@ -71,4 +73,4 @@ jobs:
 
       - name: Run chart-testing (install)
         run: |
-          ct install --config ct-install.yaml --namespace "$INSTALL_NAMESPACE"
+          ct install --config ct-install.yaml --namespace "$INSTALL_NAMESPACE" $TEST_ALL_CHARTS_ARG

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.5.0
         with:
-          node_image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+          node_image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Login to Quay.io

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INSTALL_NAMESPACE: alfresco
+      # See latest https://github.com/kubernetes-sigs/kind/releases for the latest available builds
+      KIND_NODE_IMAGE: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
       TEST_ALL_CHARTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci-test-all') && 'true' || 'false' }}
       TEST_ALL_CHARTS_ARG: ${{ contains(github.event.pull_request.labels.*.name, 'ci-test-all') && '--all' || '' }}
     steps:
@@ -53,7 +55,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.5.0
         with:
-          node_image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+          node_image: ${{ env.KIND_NODE_IMAGE }}
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Login to Quay.io


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/kind/releases/tag/v0.17.0

* add support for testing all charts via `ci-test-all` label