### PR TITLE
OPSEXP-1853: remove resource naming related named templates

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 1.0.1
+version: 2.0.0
 dependencies:
   - name: common
     repository: >-

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-search.tpl
+++ b/charts/alfresco-common/templates/_helpers-search.tpl
@@ -1,33 +1,4 @@
 {{/*
-Create a default fully qualified name.
-*/}}
-{{- define "alfresco-search.fullName" -}}
-{{- printf "%s-alfresco-search" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Alfresco Search2 Host
-*/}}
-{{- define "alfresco-search.host" -}}
-{{- if index $.Values "alfresco-search" "enabled" -}}
-  {{ printf "%s-solr" (include "alfresco-search.fullName" .) -}}
-{{- else -}}
-  {{ index $.Values "alfresco-search" "external" "host" | default "localhost" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Get Alfresco Search Port
-*/}}
-{{- define "alfresco-search.port" -}}
-{{- if index $.Values "alfresco-search" "enabled" -}}
-  {{ print (index .Values "alfresco-search" "service" "externalPort") -}}
-{{- else -}}
-  {{ index $.Values "alfresco-search" "external" "port" | default "8983" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Get Alfresco Solr context
 */}}
 {{- define "alfresco-search.baseurl" -}}


### PR DESCRIPTION
Ref: OPSEXP-1853

While making search chart independant I needed to put some named templates back into the new chart. So some cleanup is necessary to avoid conflicts