### PR TITLE
OPSPEXP-1854: add a repo helper usable from parent chart

### DIFF
--- a/charts/alfresco-sync-service/Chart.yaml
+++ b/charts/alfresco-sync-service/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 name: alfresco-sync-service
 sources:
   - https://github.com/Alfresco/acs-deployment
-version: 4.0.1
+version: 4.0.2
 appVersion: 4.0.0-M7
 icon: https://avatars0.githubusercontent.com/u/391127?s=200&v=4
 dependencies:

--- a/charts/alfresco-sync-service/README.md
+++ b/charts/alfresco-sync-service/README.md
@@ -1,6 +1,6 @@
 # alfresco-sync-service
 
-![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: 4.0.0-M7](https://img.shields.io/badge/AppVersion-4.0.0--M7-informational?style=flat-square)
+![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![AppVersion: 4.0.0-M7](https://img.shields.io/badge/AppVersion-4.0.0--M7-informational?style=flat-square)
 
 Alfresco Sync Service
 
@@ -64,8 +64,9 @@ Alfresco Sync Service
 | readinessProbe.periodSeconds | int | `10` |  |
 | readinessProbe.timeoutSeconds | int | `10` |  |
 | replicaCount | int | `1` |  |
-| repository.host | string | `"alfresco-cs-repository"` |  |
-| repository.port | int | `80` |  |
+| repository.host | string | `"alfresco-cs-repository"` | ACS repository host |
+| repository.nameOverride | string | `nil` | A nameOverride use to compute an ACS repository service name |
+| repository.port | int | `80` | ACS repository port |
 | resources.limits.cpu | string | `"2"` |  |
 | resources.limits.memory | string | `"2000Mi"` |  |
 | resources.requests.cpu | string | `"0.5"` |  |

--- a/charts/alfresco-sync-service/templates/_helpers.tpl
+++ b/charts/alfresco-sync-service/templates/_helpers.tpl
@@ -18,3 +18,11 @@ chart: {{ .Chart.Name }}
 {{ include "syncservice.selectorLabels" . }}
 heritage: {{ .Release.Service }}
 {{- end }}
+
+{{- define "syncservice.repository" -}}
+{{- if .Values.repository.nameOverride }}
+{{- printf "%s-%s" .Release.Name .Values.repository.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.repository.host }}
+{{- end }}
+{{- end -}}

--- a/charts/alfresco-sync-service/templates/config-syncservice.yaml
+++ b/charts/alfresco-sync-service/templates/config-syncservice.yaml
@@ -11,7 +11,7 @@ data:
       -Dsql.db.driver={{ include "syncservice.dbDriver" . | quote }}
       -Dsql.db.username=$DATABASE_USERNAME
       -Dsql.db.password=$DATABASE_PASSWORD
-      -Drepo.hostname={{ .Values.repository.host }}
+      -Drepo.hostname={{ template "syncservice.repository" . }}
       -Drepo.port={{ .Values.repository.port }}
       -Ddw.server.applicationConnectors[0].type=http
       -Dmessaging.broker.url=$BROKER_URL

--- a/charts/alfresco-sync-service/tests/repo_test.yaml
+++ b/charts/alfresco-sync-service/tests/repo_test.yaml
@@ -1,0 +1,50 @@
+---
+suite: test deployment
+templates:
+  - config-syncservice.yaml
+tests:
+  - it: should render default options
+    set:
+      postgresql:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data.JAVA_OPTS
+          pattern: >-
+            -Drepo.hostname=alfresco-cs-repository\s+
+      - matchRegex:
+          path: data.JAVA_OPTS
+          pattern: >-
+            -Drepo.port=80\s+
+  - it: should render options based on repo nameOverride
+    set:
+      postgresql:
+        enabled: true
+      repository:
+        nameOverride: myKnownServiceName
+        port: 8080
+    asserts:
+      - matchRegex:
+          path: data.JAVA_OPTS
+          pattern: >-
+            -Drepo.hostname=RELEASE-NAME-myKnownServiceName\s+
+      - matchRegex:
+          path: data.JAVA_OPTS
+          pattern: >-
+            -Drepo.port=8080\s+
+  - it: should render options as provided in values
+    set:
+      postgresql:
+        enabled: true
+      repository:
+        host: somerepohost
+        port: 8888
+    asserts:
+      - matchRegex:
+          path: data.JAVA_OPTS
+          pattern: >-
+            -Drepo.hostname=somerepohost\s+
+      - matchRegex:
+          path: data.JAVA_OPTS
+          pattern: >-
+            -Drepo.port=8888\s+

--- a/charts/alfresco-sync-service/values.yaml
+++ b/charts/alfresco-sync-service/values.yaml
@@ -53,8 +53,12 @@ readinessProbe:
   failureThreshold: 12
   timeoutSeconds: 10
 repository:
+  # -- ACS repository host
   host: alfresco-cs-repository
+  # -- ACS repository port
   port: 80
+  # -- A nameOverride use to compute an ACS repository service name
+  nameOverride:
 activemq:
   # -- Toggle ActiveMQ chart dependency
   # see [Alfresco ActiveMQ chart


### PR DESCRIPTION
acs-deployment approach requires to be able to expand repo service name from release name