### PR TITLE
OPSEXP-1861: allow using charts names overrides without installing the chart itself

### DIFF
--- a/charts/alfresco-transform-service/Chart.yaml
+++ b/charts/alfresco-transform-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-transform-service
 description: A Helm chart for deploying Alfresco Transform Services
 type: application
-version: 0.1.0-alpha.0
+version: 0.1.0-alpha.1
 appVersion: "3.0.0"
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-transform-service/README.md
+++ b/charts/alfresco-transform-service/README.md
@@ -18,8 +18,9 @@ A Helm chart for deploying Alfresco Transform Services
 |-----|------|---------|-------------|
 | activemq.adminUser.password | string | `"admin"` | Default password for the embedded broker admin user |
 | activemq.adminUser.user | string | `"admin"` | Default username for the embedded broker admin user |
-| activemq.enabled | bool | `false` |  |
-| activemq.nameOverride | string | `"activemq"` |  |
+| activemq.enabled | bool | `false` | Deploy ActiveMQ chart as a dependency dependencies should only be called from the root chart |
+| activemq.fullnameOverride | string | `nil` | Provide a static name that's used accross the whole Helm release |
+| activemq.nameOverride | string | `nil` | Provide a partially static name that's used accross the whole Helm release |
 | activemq.nodeSelector | object | `{}` | Possibility to choose Node for pod, with a key-value pair label e.g {"kubernetes.io/hostname": multinode-demo-m02} |
 | ai.enabled | bool | `false` |  |
 | ai.nameOverride | string | `"alfresco-ai"` |  |

--- a/charts/alfresco-transform-service/README.md
+++ b/charts/alfresco-transform-service/README.md
@@ -1,6 +1,6 @@
 # alfresco-transform-service
 
-![Version: 0.1.0-alpha.0](https://img.shields.io/badge/Version-0.1.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Transform Services
 

--- a/charts/alfresco-transform-service/ci/default-values.yaml
+++ b/charts/alfresco-transform-service/ci/default-values.yaml
@@ -1,5 +1,6 @@
 activemq:
   enabled: true
+  nameOverride: activemq
   resources:
     requests:
       cpu: "100m"

--- a/charts/alfresco-transform-service/templates/secret-messagebroker.yaml
+++ b/charts/alfresco-transform-service/templates/secret-messagebroker.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "alfresco-transform-service.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.activemq.enabled }}
+  {{- if or .Values.activemq.enabled .Values.activemq.nameOverride .Values.activemq.fullnameOverride }}
   BROKER_URL: {{ printf "failover:(nio://%s-broker:61616)?timeout=3000&jms.useCompression=true" (include "alfresco-transform-service.fullname" (dict "Values" .Values.activemq "Chart" .Chart "Release" .Release)) | b64enc | quote }}
   BROKER_USERNAME: {{ .Values.activemq.adminUser.user | b64enc | quote }}
   BROKER_PASSWORD: {{ .Values.activemq.adminUser.password | b64enc | quote }}

--- a/charts/alfresco-transform-service/values.yaml
+++ b/charts/alfresco-transform-service/values.yaml
@@ -312,8 +312,13 @@ filestore:
       subPath: "alfresco-content-services/filestore-data"
 
 activemq:
-  nameOverride: activemq
+  # -- Deploy ActiveMQ chart as a dependency
+  # dependencies should only be called from the root chart
   enabled: false
+  # -- Provide a partially static name that's used accross the whole Helm release
+  nameOverride: null
+  # -- Provide a static name that's used accross the whole Helm release
+  fullnameOverride: null
   # -- Possibility to choose Node for pod, with a key-value pair label
   # e.g {"kubernetes.io/hostname": multinode-demo-m02}
   nodeSelector: {}
@@ -330,7 +335,8 @@ messageBroker:
   password: null
   # -- Name of the secret managed by this chart
   secretName: acs-alfresco-cs-brokersecret
-  # -- Alternatively, provide credentials via an existing secret that contains BROKER_URL, BROKER_USERNAME and BROKER_PASSWORD keys
+  # -- Alternatively, provide credentials via an existing secret that contains
+  # BROKER_URL, BROKER_USERNAME and BROKER_PASSWORD keys
   existingSecretName: null
 
 ai:


### PR DESCRIPTION
Required to avoid issues such as: https://github.com/Alfresco/acs-deployment/actions/runs/5453623178/jobs/9922696450#step:4:31