### PR TITLE
OPSEXP-2188: pass whole context for better reusability in building urls

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 2.1.0-alpha.0
+version: 2.1.0-alpha.1
 dependencies:
   - name: common
     repository: >-

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 2.1.0-alpha.0](https://img.shields.io/badge/Version-2.1.0--alpha.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 2.1.0-alpha.1](https://img.shields.io/badge/Version-2.1.0--alpha.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-url.tpl
+++ b/charts/alfresco-common/templates/_helpers-url.tpl
@@ -1,13 +1,20 @@
 {{/*
+Known URLs are the URL we can trust
+*/}}
+{{- define "alfresco-common.known.urls" -}}
+{{- $known_urls := coalesce .Values.known_urls .Values.global.known_urls "http://localhost,https://localhost" }}
+{{- if kindIs "string" $known_urls }}
+  {{- $known_urls = splitList "," $known_urls }}
+{{- end }}
+{{- mustToJson (dict "known_urls" $known_urls) }}
+{{- end -}}
+
+{{/*
 Build up CSRF referer
 */}}
 {{- define "alfresco-common.csrf.referer" -}}
-{{- $known_urls := . }}
 {{- $csrf_referers := list }}
-{{- if kindIs "string" . }}
-  {{- $known_urls = splitList "," . }}
-{{- end }}
-{{- range $known_urls }}
+{{- range index (include "alfresco-common.known.urls" . | fromJson) "known_urls" }}
   {{- $parsed_url := urlParse . }}
   {{- $known_url := urlJoin (dict "host" $parsed_url.host "path" $parsed_url.path "scheme" $parsed_url.scheme) }}
   {{- $csrf_referers = append $csrf_referers $known_url }}
@@ -19,12 +26,8 @@ Build up CSRF referer
 Build up CSRF Origin
 */}}
 {{- define "alfresco-common.csrf.origin" -}}
-{{- $known_urls := . }}
 {{- $csrf_origins := list }}
-{{- if kindIs "string" . }}
-  {{- $known_urls = splitList "," . }}
-{{- end }}
-{{- range $known_urls }}
+{{- range index (include "alfresco-common.known.urls" . | fromJson) "known_urls" }}
   {{- $parsed_url := urlParse . }}
   {{- $known_url := urlJoin (dict "host" $parsed_url.host "scheme" $parsed_url.scheme) }}
   {{- $csrf_origins = append $csrf_origins $known_url }}
@@ -33,13 +36,36 @@ Build up CSRF Origin
 {{- end -}}
 
 {{/*
-Pick the main external host
+Pick the main external URL
 */}}
 {{- define "alfresco-common.external.url" -}}
-{{- $known_urls := .}}
-{{- if kindIs "string" . }}
-  {{- $known_urls = splitList "," . }}
-{{- end }}
-{{- $parsed_url := urlParse (first $known_urls) }}
+{{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
 {{- urlJoin (dict "host" $parsed_url.host "scheme" $parsed_url.scheme) }}
+{{- end -}}
+
+{{/*
+Pick the main external host
+*/}}
+{{- define "alfresco-common.external.host" -}}
+{{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
+{{- $parsed_url.host }}
+{{- end -}}
+
+{{/*
+Pick the main external port.
+Returns empty if not specified, consuming template should handle defaults
+*/}}
+{{- define "alfresco-common.external.port" -}}
+{{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
+{{- if gt ($parsed_url.host | splitList ":") 1 }}
+  {{- $parsed_url.host | splitList ":" | last }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Pick the main external scheme
+*/}}
+{{- define "alfresco-common.external.scheme" -}}
+{{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
+{{- $parsed_url.scheme }}
 {{- end -}}


### PR DESCRIPTION
allow for better integration in acs-deployment and useful when making repo a dedicated chart as well