### PR TITLE
OPSEXP-2188: improve url building template in alfresco-common

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 2.1.0-alpha.1
+version: 2.1.0-alpha.2
 dependencies:
   - name: common
     repository: >-

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 2.1.0-alpha.1](https://img.shields.io/badge/Version-2.1.0--alpha.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 2.1.0-alpha.2](https://img.shields.io/badge/Version-2.1.0--alpha.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-url.tpl
+++ b/charts/alfresco-common/templates/_helpers-url.tpl
@@ -57,7 +57,7 @@ Returns empty if not specified, consuming template should handle defaults
 */}}
 {{- define "alfresco-common.external.port" -}}
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
-{{- if gt ($parsed_url.host | splitList ":") 1 }}
+{{- if gt ($parsed_url.host | splitList ":" | len) 1 }}
   {{- $parsed_url.host | splitList ":" | last }}
 {{- end }}
 {{- end -}}

--- a/charts/alfresco-common/templates/_helpers-url.tpl
+++ b/charts/alfresco-common/templates/_helpers-url.tpl
@@ -6,6 +6,11 @@ Known URLs are the URL we can trust
 {{- if kindIs "string" $known_urls }}
   {{- $known_urls = splitList "," $known_urls }}
 {{- end }}
+{{- range $known_urls }}
+{{- if not (or (hasPrefix "http://" .) (hasPrefix "https://" .)) }}
+{{- fail "provided known_urls MUST start with a scheme (http :// or https://)" }}
+{{- end }}
+{{- end }}
 {{- mustToJson (dict "known_urls" $known_urls) }}
 {{- end -}}
 
@@ -48,17 +53,18 @@ Pick the main external host
 */}}
 {{- define "alfresco-common.external.host" -}}
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
-{{- $parsed_url.host }}
+{{- $parsed_url.host | splitList ":" | first }}
 {{- end -}}
 
 {{/*
 Pick the main external port.
-Returns empty if not specified, consuming template should handle defaults
 */}}
 {{- define "alfresco-common.external.port" -}}
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
 {{- if gt ($parsed_url.host | splitList ":" | len) 1 }}
   {{- $parsed_url.host | splitList ":" | last }}
+{{- else }}
+  {{- eq (include "alfresco-common.external.scheme" .) "https" | ternary 443 80 }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Ref: OPSEXP-2188
* fixes a problem with list length comparison
* add sanitizer to named templates
* returns default if none is present in input
