### PR TITLE
OPSEXP-2077 Fixup Checkov not really linting all charts

### DIFF
--- a/.checkov-values.yml
+++ b/.checkov-values.yml
@@ -1,0 +1,9 @@
+postgresql:
+  enabled: true
+activemq:
+  enabled: true
+elasticsearch:
+  enabled: true
+global:
+  tracking:
+    sharedsecret: dummy

--- a/.checkov.yml
+++ b/.checkov.yml
@@ -10,3 +10,8 @@ skip-check:
   - CKV_K8S_35
   - CKV_K8S_38
   - CKV_K8S_43
+var-file: .checkov-values.yml
+skip-path:
+  - charts/alfresco-common
+  - charts/postgresql
+  - charts/elasticsearch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
     rev: 2.3.130
     hooks:
       - id: checkov
-        files: \.yaml$
+        files: charts/.*\.yaml$
+        verbose: true
         args:
         - --quiet
         - --compact


### PR DESCRIPTION
Ref: OPSEXP-2077

* Add `verbose` which seems the only way to actually get some feedback if things get wrong again
* Make sure to execute checkov locally only for changed charts files
* Skip 3rd party charts and our library chart which can't be scan