### PR TITLE
OPSEXP-1862: move named tpl in alfresco-common

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 2.1.0-alpha.2
+version: 2.1.0-alpha.3
 dependencies:
   - name: common
     repository: >-

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 2.1.0-alpha.2](https://img.shields.io/badge/Version-2.1.0--alpha.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 2.1.0-alpha.3](https://img.shields.io/badge/Version-2.1.0--alpha.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-activemq.tpl
+++ b/charts/alfresco-common/templates/_helpers-activemq.tpl
@@ -1,4 +1,10 @@
-{{- define "activemq.env" -}}
+{{/*
+Provide generic ActiveMQ env vars
+
+Usage: include "alfresco-common.activemq.env" ""
+
+*/}}
+{{- define "alfresco-common.activemq.env" -}}
 - name: ACTIVEMQ_URL
   value: $(BROKER_URL)
 - name: ACTIVEMQ_USER
@@ -7,11 +13,25 @@
   value: $(BROKER_PASSWORD)
 {{- end -}}
 
-{{- define "spring.activemq.env" -}}
+{{- define "activemq.env" -}}
+{{- template "alfresco-common.activemq.env" . }}
+{{- end -}}
+
+{{/*
+Provide Spring ActiveMQ env vars
+
+Usage: include "alfresco-common.spring.activemq.env" ""
+
+*/}}
+{{- define "alfresco-common.spring.activemq.env" -}}
 - name: SPRING_ACTIVEMQ_BROKERURL
   value: $(BROKER_URL)
 - name: SPRING_ACTIVEMQ_USER
   value: $(BROKER_USERNAME)
 - name: SPRING_ACTIVEMQ_PASSWORD
   value: $(BROKER_PASSWORD)
+{{- end -}}
+
+{{- define "spring.activemq.env" -}}
+{{- template "alfresco-common.spring.activemq.env" . }}
 {{- end -}}

--- a/charts/alfresco-common/templates/_helpers-checksums.tpl
+++ b/charts/alfresco-common/templates/_helpers-checksums.tpl
@@ -7,10 +7,13 @@ Usage: include "alfresco-common.secret-checksum" (dict "ns" $.Release.Namespace 
 {{- define "alfresco-common.secret-checksum" -}}
 {{- $ns := required "template needs to be given the release namepace" .ns }}
 {{- with (index .context .configKey) }}
-checksum.config.alfresco.org/{{ $.configKey }}-values: {{ omit . "existingSecret" | toJson | sha256sum }}
+{{- if .existingSecret.name }}
 checksum.config.alfresco.org/{{ $.configKey }}-existing:
-  {{- $defaultLookup := (dict "existingSecret" (dict "keys" dict)) }}
-  {{- $lookup := ((lookup "v1" "Secret" $ns ( .existingSecret.name | default "")).data | default $defaultLookup) }}
-  {{- pick $lookup .existingSecret.keys.username .existingSecret.keys.password | toJson | sha256sum | indent 1}}
+  {{- $defaultLookup := dict "data" dict }}
+  {{- $lookup := lookup "v1" "Secret" $ns (.existingSecret.name) | default $defaultLookup }}
+  {{- pick $lookup.data .existingSecret.keys.username .existingSecret.keys.password | toJson | sha256sum | indent 1}}
+{{- else }}
+checksum.config.alfresco.org/{{ $.configKey }}-values: {{ omit . "existingSecret" | toJson | sha256sum }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/alfresco-common/templates/_helpers-checksums.tpl
+++ b/charts/alfresco-common/templates/_helpers-checksums.tpl
@@ -1,0 +1,16 @@
+{{/*
+Compute Secret checksum whether it's read from values or from secrets
+
+Usage: include "alfresco-common.secret-checksum" (dict "ns" $.Release.Namespace "context" $ "configKey" (dict "some-key" (dict "existingSecret" (dict "keys" (dict "username" "" "password" "")))))
+
+*/}}
+{{- define "alfresco-common.secret-checksum" -}}
+{{- $release := required "alfresco-repository.secret-checksum needs to be given the release name" .release }}
+{{- with (index .context .configKey) }}
+checksum.config.alfresco.org/{{ $.configKey }}-values: {{ omit . "existingSecret" | toJson | sha256sum }}
+checksum.config.alfresco.org/{{ $.configKey }}-existing:
+  {{- $defaultLookup := (dict "existingSecret" (dict "keys" dict)) }}
+  {{- $lookup := ((lookup "v1" "Secret" $release ( .existingSecret.name | default "")).data | default $defaultLookup) }}
+  {{- pick $lookup .existingSecret.keys.username .existingSecret.keys.password | toJson | sha256sum | indent 1}}
+{{- end }}
+{{- end -}}

--- a/charts/alfresco-common/templates/_helpers-checksums.tpl
+++ b/charts/alfresco-common/templates/_helpers-checksums.tpl
@@ -1,16 +1,16 @@
 {{/*
 Compute Secret checksum whether it's read from values or from secrets
 
-Usage: include "alfresco-common.secret-checksum" (dict "ns" $.Release.Namespace "context" $ "configKey" (dict "some-key" (dict "existingSecret" (dict "keys" (dict "username" "" "password" "")))))
+Usage: include "alfresco-common.secret-checksum" (dict "ns" $.Release.Namespace "context" (dict "some-key" (dict "existingSecret" (dict "keys" (dict "username" "" "password" "")))) "configKey" "some-key")
 
 */}}
 {{- define "alfresco-common.secret-checksum" -}}
-{{- $release := required "alfresco-repository.secret-checksum needs to be given the release name" .release }}
+{{- $ns := required "template needs to be given the release namepace" .ns }}
 {{- with (index .context .configKey) }}
 checksum.config.alfresco.org/{{ $.configKey }}-values: {{ omit . "existingSecret" | toJson | sha256sum }}
 checksum.config.alfresco.org/{{ $.configKey }}-existing:
   {{- $defaultLookup := (dict "existingSecret" (dict "keys" dict)) }}
-  {{- $lookup := ((lookup "v1" "Secret" $release ( .existingSecret.name | default "")).data | default $defaultLookup) }}
+  {{- $lookup := ((lookup "v1" "Secret" $ns ( .existingSecret.name | default "")).data | default $defaultLookup) }}
   {{- pick $lookup .existingSecret.keys.username .existingSecret.keys.password | toJson | sha256sum | indent 1}}
 {{- end }}
 {{- end -}}

--- a/charts/alfresco-common/templates/_helpers-image-pull-secrets.tpl
+++ b/charts/alfresco-common/templates/_helpers-image-pull-secrets.tpl
@@ -1,6 +1,16 @@
-{{- define "alfresco-content-services.imagePullSecrets" }}
+{{/*
+Read pull secrets from .Values.global
+
+Usage: include "alfresco-common.imagePullSecrets" $
+
+*/}}
+{{- define "alfresco-common.imagePullSecrets" }}
 {{- if .Values.global.alfrescoRegistryPullSecrets }}
 imagePullSecrets:
   - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
 {{- end }}
+{{- end }}
+
+{{- define "alfresco-content-services.imagePullSecrets" }}
+{{- template "alfresco-common.imagePullSecrets" . }}
 {{- end }}

--- a/charts/alfresco-common/templates/_helpers-jdbc.tpl
+++ b/charts/alfresco-common/templates/_helpers-jdbc.tpl
@@ -48,10 +48,10 @@ Usage: include "alfresco-common.jdbc.parser" "URL"
 {{/*
 Compute default ports based on URL
 
-Usage: include "alfresco-comon.db.default.port" "URL"
+Usage: include "alfresco-common.db.default.port" "URL"
 
 */}}
-{{- define "alfresco-comon.db.default.port" -}}
+{{- define "alfresco-common.db.default.port" -}}
 {{- $pg_rdbms := dict "name" "postgresql" "port" 5432 }}
 {{- $my_rdbms := dict "name" "mysql" "port" 3306 }}
 {{- $maria_rdbms := dict "name" "mariadb" "port" 3306 }}
@@ -65,10 +65,10 @@ Usage: include "alfresco-comon.db.default.port" "URL"
 {{/*
 Compute default driver based on URL
 
-Usage: include "alfresco-comon.db.default.driver" "URL"
+Usage: include "alfresco-common.db.default.driver" "URL"
 
 */}}
-{{- define "alfresco-comon.db.default.driver" -}}
+{{- define "alfresco-common.db.default.driver" -}}
 {{- $pg_rdbms := dict "name" "postgresql" "driver" "org.postgresql.Driver" }}
 {{- $my_rdbms := dict "name" "mysql" "driver" "com.mysql.jdbc.Driver" }}
 {{- $maria_rdbms := dict "name" "mariadb" "driver" "org.mariadb.jdbc.Driver" }}
@@ -110,7 +110,7 @@ Usage: include "alfresco-common.db.port" (dict "url" "someurl")
 {{- if gt ($socket | splitList ":" | len) 1 }}
   {{- $socket | splitList ":" | last }}
 {{- else }}
-  {{- template "alfresco-comon.db.default.port" (index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "scheme") }}
+  {{- template "alfresco-common.db.default.port" (index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "scheme") }}
 {{- end }}
 {{- end -}}
 
@@ -122,5 +122,5 @@ Usage: include "alfresco-common.db.driver" (dict "url" "someurl" "driver" "drive
 */}}
 {{- define "alfresco-common.db.driver" -}}
 {{- $scheme := index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "scheme" }}
-{{- coalesce .driver (include "alfresco-comon.db.default.driver" $scheme) }}
+{{- coalesce .driver (include "alfresco-common.db.default.driver" $scheme) }}
 {{- end -}}

--- a/charts/alfresco-common/templates/_helpers-jdbc.tpl
+++ b/charts/alfresco-common/templates/_helpers-jdbc.tpl
@@ -1,0 +1,126 @@
+{{/*
+Compute a JDBC URL object
+We're just manipulating the string URl to make it parseable by urlParse.
+This template SHOULD NOT be used directly.
+
+Usage: include "alfresco-common.jdbc.parser" "URL"
+
+*/}}
+{{- define "alfresco-common.jdbc.parser" -}}
+{{- $jdbc_url := required "Alfresco repository needs a database to start. Please provide a valid URL in db.url value" . }}
+{{- if hasPrefix "jdbc:" $jdbc_url }}
+{{- fail "database URL MUST be provided WITHOUT the 'jdbc' prefix." }}
+{{- end }}
+{{- if hasPrefix "oracle:thin:@" $jdbc_url }}
+  {{- $ora_url := trimPrefix "oracle:thin:" $jdbc_url }}
+  {{- $ora_url = (mustRegexReplaceAllLiteral "^@(tcps?://)?" $ora_url "oracle://") }}
+  {{- $jdbc_url = $ora_url }}
+{{- end }}
+{{- if hasPrefix "sqlserver://" $jdbc_url }}
+  {{- $jdbc_url = trimPrefix "sqlserver://" $jdbc_url }}
+  {{- $query := $jdbc_url | splitList ";" }}
+  {{- $host := "" }}
+  {{- if and (not (empty (index $query 0))) (not (contains "=" (index $query 0))) }}
+    {{- $host = index $query 0 }}
+    {{- $query = rest $query }}
+  {{- end }}
+  {{- $path := "" }}
+  {{- range $query }}
+    {{- if and (hasPrefix "serverName=" .) (empty $host) }}
+      {{- $host = trimPrefix "serverName=" . }}
+      {{- $_ := mustWithout $query . }}
+    {{- end }}
+    {{- if hasPrefix "databaseName=" . }}
+      {{- $path = trimPrefix "databaseName=" . }}
+      {{- $_ := mustWithout $query . }}
+    {{- end }}
+  {{- end }}
+  {{- $ms_url := printf "sqlserver://%s/%s?%s" $host $path ($query | join "&") }}
+  {{- $jdbc_url = $ms_url }}
+{{- end }}
+{{- $parsed_url := urlParse $jdbc_url }}
+{{- if or (empty $parsed_url.host) (empty $parsed_url.hostname) (empty $parsed_url.scheme) (eq "/" $parsed_url.path) }}
+  {{- fail "The provided JDBC URL cannot be parsed please check or raise a bug." }}
+{{- end }}
+{{- mustToJson (dict "jdbc" $parsed_url) }}
+{{- end -}}
+
+{{/*
+Compute default ports based on URL
+
+Usage: include "alfresco-comon.db.default.port" "URL"
+
+*/}}
+{{- define "alfresco-comon.db.default.port" -}}
+{{- $pg_rdbms := dict "name" "postgresql" "port" 5432 }}
+{{- $my_rdbms := dict "name" "mysql" "port" 3306 }}
+{{- $maria_rdbms := dict "name" "mariadb" "port" 3306 }}
+{{- $ora_rdbms := dict "name" "oracle" "port" 1521 }}
+{{- $ms_rdbms := dict "name" "sqlserver" "port" 1434 }}
+{{- range $rdbms := list $pg_rdbms $my_rdbms $maria_rdbms $ora_rdbms $ms_rdbms }}
+{{- eq $rdbms.name $ | ternary $rdbms.port "" }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Compute default driver based on URL
+
+Usage: include "alfresco-comon.db.default.driver" "URL"
+
+*/}}
+{{- define "alfresco-comon.db.default.driver" -}}
+{{- $pg_rdbms := dict "name" "postgresql" "driver" "org.postgresql.Driver" }}
+{{- $my_rdbms := dict "name" "mysql" "driver" "com.mysql.jdbc.Driver" }}
+{{- $maria_rdbms := dict "name" "mariadb" "driver" "org.mariadb.jdbc.Driver" }}
+{{- $ora_rdbms := dict "name" "oracle" "driver" "oracle.jdbc.OracleDriver" }}
+{{- $ms_rdbms := dict "name" "sqlserver" "driver" "com.microsoft.sqlserver.jdbc.SQLServerDriver" }}
+{{- range $rdbms := list $pg_rdbms $my_rdbms $maria_rdbms $ora_rdbms $ms_rdbms }}
+{{- eq $rdbms.name $ | ternary $rdbms.driver "" }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Provide repository database engine from URL
+
+Usage: include "alfresco-common.db.rdbms" "URL"
+
+*/}}
+{{- define "alfresco-common.db.rdbms" -}}
+{{- index (include "alfresco-common.jdbc.parser" . | fromJson) "jdbc" "scheme" }}
+{{- end -}}
+
+{{/*
+Provide repository database hostname
+
+Usage: include "alfresco-common.db.hostname" "URL"
+
+*/}}
+{{- define "alfresco-common.db.hostname" -}}
+{{- index (include "alfresco-common.jdbc.parser" . | fromJson) "jdbc" "hostname" }}
+{{- end -}}
+
+{{/*
+Provide database port from JDBC URL
+
+Usage: include "alfresco-common.db.port" (dict "url" "someurl")
+
+*/}}
+{{- define "alfresco-common.db.port" -}}
+{{- $socket := (index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "host") }}
+{{- if gt ($socket | splitList ":" | len) 1 }}
+  {{- $socket | splitList ":" | last }}
+{{- else }}
+  {{- template "alfresco-comon.db.default.port" (index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "scheme") }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Provide database driverClass based on  JDBC URL
+
+Usage: include "alfresco-common.db.driver" (dict "url" "someurl" "driver" "driverclass")
+
+*/}}
+{{- define "alfresco-common.db.driver" -}}
+{{- $scheme := index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "scheme" }}
+{{- coalesce .driver (include "alfresco-comon.db.default.driver" $scheme) }}
+{{- end -}}

--- a/charts/alfresco-common/templates/_helpers-nginx.tpl
+++ b/charts/alfresco-common/templates/_helpers-nginx.tpl
@@ -1,6 +1,9 @@
 {{/*
 Define annotations as provided in values
 Skip ANY server-snippet annotation (CVE-2021-25742)
+
+Usage: include "alfresco-common.nginx.annotations" $
+
 */}}
 {{- define "alfresco-common.nginx.annotations" }}
 {{- range $annotation, $value := .ingress.annotations }}
@@ -13,6 +16,9 @@ Skip ANY server-snippet annotation (CVE-2021-25742)
 
 {{/*
 Define required annotations for secure ACS/SHARE API access
+
+Usage: include "alfresco-common.nginx.secure.annotations" ""
+
 */}}
 {{- define "alfresco-common.nginx.secure.annotations" }}
     nginx.ingress.kubernetes.io/server-snippet: |

--- a/charts/alfresco-common/templates/_helpers-persistence.tpl
+++ b/charts/alfresco-common/templates/_helpers-persistence.tpl
@@ -1,4 +1,10 @@
-{{- define "data_volume" -}}
+{{/*
+Provide a PVC based on service and persistence values
+
+Usage: include "alfresco-common.data_volume" $
+
+*/}}
+{{- define "alfresco-comon.data_volume" -}}
 - name: data
 {{- $svc_name := .service.name }}
 {{- with .persistence }}
@@ -14,7 +20,17 @@
 {{- end }}
 {{- end -}}
 
-{{- define "component_pvc" -}}
+{{- define "data_volume" -}}
+{{- template "alfresco-common.data_volume" . }}
+{{- end -}}
+
+{{/*
+Provide a PVC based on service and persistence values
+
+Usage: include "alfresco-common.component_pvc" $
+
+*/}}
+{{- define "alfresco-common.component_pvc" -}}
 {{ $svc_name := .service.name }}
 {{- with .persistence }}
 {{- $sc_name := .storageClass | default "default" -}}
@@ -38,4 +54,8 @@ spec:
     requests:
       storage: {{ .baseSize | default "20Gi" | quote }}
 {{- end }}
+{{- end -}}
+
+{{- define "component_pvc" -}}
+{{- template "alfresco-common.component_pvc" . }}
 {{- end -}}

--- a/charts/alfresco-common/templates/_helpers-persistence.tpl
+++ b/charts/alfresco-common/templates/_helpers-persistence.tpl
@@ -4,7 +4,7 @@ Provide a PVC based on service and persistence values
 Usage: include "alfresco-common.data_volume" $
 
 */}}
-{{- define "alfresco-comon.data_volume" -}}
+{{- define "alfresco-common.data_volume" -}}
 - name: data
 {{- $svc_name := .service.name }}
 {{- with .persistence }}

--- a/charts/alfresco-common/templates/_helpers-security.tpl
+++ b/charts/alfresco-common/templates/_helpers-security.tpl
@@ -1,10 +1,26 @@
-{{- define "default-pod-security-context" }}
+{{/*
+Provide default pod security context
+
+Usage: include "alfresco-common.default-pod-security-context" ""
+
+*/}}
+{{- define "alfresco-common.default-pod-security-context" }}
     runAsNonRoot: true
     runAsUser: 33099
     fsGroupChangePolicy: OnRootMismatch
 {{- end }}
 
-{{- define "default-security-context" }}
+{{- define "default-pod-security-context" }}
+{{- template "alfresco-common.default-pod-security-context" . }}
+{{- end }}
+
+{{/*
+Provide default container security context
+
+Usage: include "alfresco-common.default-security-context" ""
+
+*/}}
+{{- define "alfresco-common.default-security-context" }}
     runAsNonRoot: true
     allowPrivilegeEscalation: false
     capabilities:
@@ -13,7 +29,17 @@
         - ALL
 {{- end }}
 
-{{- define "component-pod-security-context" }}
+{{- define "default-security-context" }}
+{{- template "alfresco-common.default-security-context" . }}
+{{- end }}
+
+{{/*
+Provide pod security context
+
+Usage: include "alfresco-common.component-pod-security-context" $
+
+*/}}
+{{- define "alfresco-common.component-pod-security-context" }}
   securityContext:
 {{- if .podSecurityContext }}
     {{- .podSecurityContext | toYaml | nindent 4 }}
@@ -22,11 +48,25 @@
 {{- end }}
 {{- end }}
 
-{{- define "component-security-context" }}
+{{- define "component-pod-security-context" }}
+{{- template "alfresco-common.component-pod-security-context" $ }}
+{{- end }}
+
+{{/*
+Provide container security context
+
+Usage: include "alfresco-common.component-security-context" $
+
+*/}}
+{{- define "alfresco-common.component-security-context" }}
   securityContext:
 {{- if .securityContext }}
   {{- .securityContext | toYaml | nindent 4 }}
 {{- else }}
 {{- include "default-security-context" . }}
 {{- end }}
+{{- end }}
+
+{{- define "component-security-context" }}
+{{- template "alfresco-common.component-security-context" . }}
 {{- end }}

--- a/charts/alfresco-common/templates/_helpers-url.tpl
+++ b/charts/alfresco-common/templates/_helpers-url.tpl
@@ -96,3 +96,62 @@ Usage: include "alfresco-common.external.scheme" $
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
 {{- $parsed_url.scheme }}
 {{- end -}}
+
+{{/*
+Pick the URL scheme
+
+Usage: include "alfresco-common.url.scheme" "URL"
+
+*/}}
+{{- define "alfresco-common.url.scheme" -}}
+{{- $parsed_url := urlParse . }}
+{{- $parsed_url.scheme | default "http" }}
+{{- end -}}
+
+{{/*
+Pick the URL hostname
+
+Usage: include "alfresco-common.url.host" "URL"
+
+*/}}
+{{- define "alfresco-common.url.host" -}}
+{{- $parsed_url := urlParse . }}
+{{- $parsed_url.hostname }}
+{{- end -}}
+
+{{/*
+Pick the URL port
+
+Usage: include "alfresco-common.url.port" "URL"
+
+*/}}
+{{- define "alfresco-common.url.port" -}}
+{{- $parsed_url := urlParse . }}
+{{- if gt ($parsed_url.host | splitList ":" | len) 1 }}
+  {{- $parsed_url.host | splitList ":" | last }}
+{{- else }}
+  {{- eq (include "alfresco-common.url.scheme" .) "https" | ternary 443 80 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Pick the URL path
+
+Usage: include "alfresco-common.url.path" "URL"
+
+*/}}
+{{- define "alfresco-common.url.path" -}}
+{{- $parsed_url := urlParse . }}
+{{- $parsed_url.path }}
+{{- end -}}
+
+{{/*
+Pick the URL query params
+
+Usage: include "alfresco-common.url.query" "URL"
+
+*/}}
+{{- define "alfresco-common.url.query" -}}
+{{- $parsed_url := urlParse . }}
+{{- $parsed_url.query }}
+{{- end -}}

--- a/charts/alfresco-common/templates/_helpers-url.tpl
+++ b/charts/alfresco-common/templates/_helpers-url.tpl
@@ -1,5 +1,8 @@
 {{/*
 Known URLs are the URL we can trust
+
+Usage: include "alfresco-common.known.urls" $
+
 */}}
 {{- define "alfresco-common.known.urls" -}}
 {{- $known_urls := coalesce .Values.known_urls .Values.global.known_urls "http://localhost,https://localhost" }}
@@ -7,15 +10,18 @@ Known URLs are the URL we can trust
   {{- $known_urls = splitList "," $known_urls }}
 {{- end }}
 {{- range $known_urls }}
-{{- if not (or (hasPrefix "http://" .) (hasPrefix "https://" .)) }}
-{{- fail "provided known_urls MUST start with a scheme (http :// or https://)" }}
-{{- end }}
+  {{- if not (or (hasPrefix "http://" .) (hasPrefix "https://" .)) }}
+    {{- fail "provided known_urls MUST start with a scheme (http :// or https://)" }}
+  {{- end }}
 {{- end }}
 {{- mustToJson (dict "known_urls" $known_urls) }}
 {{- end -}}
 
 {{/*
 Build up CSRF referer
+
+Usage: include "alfresco-common.csrf.referer" $
+
 */}}
 {{- define "alfresco-common.csrf.referer" -}}
 {{- $csrf_referers := list }}
@@ -29,6 +35,9 @@ Build up CSRF referer
 
 {{/*
 Build up CSRF Origin
+
+Usage: include "alfresco-common.csrf.origin" $
+
 */}}
 {{- define "alfresco-common.csrf.origin" -}}
 {{- $csrf_origins := list }}
@@ -42,6 +51,9 @@ Build up CSRF Origin
 
 {{/*
 Pick the main external URL
+
+Usage: include "alfresco-common.external.url" $
+
 */}}
 {{- define "alfresco-common.external.url" -}}
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
@@ -50,6 +62,9 @@ Pick the main external URL
 
 {{/*
 Pick the main external host
+
+Usage: include "alfresco-common.external.host" $
+
 */}}
 {{- define "alfresco-common.external.host" -}}
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
@@ -58,6 +73,9 @@ Pick the main external host
 
 {{/*
 Pick the main external port.
+
+Usage: include "alfresco-common.external.port" $
+
 */}}
 {{- define "alfresco-common.external.port" -}}
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}
@@ -70,6 +88,9 @@ Pick the main external port.
 
 {{/*
 Pick the main external scheme
+
+Usage: include "alfresco-common.external.scheme" $
+
 */}}
 {{- define "alfresco-common.external.scheme" -}}
 {{- $parsed_url := urlParse (index (include "alfresco-common.known.urls" . | fromJson) "known_urls" | first) }}


### PR DESCRIPTION
Ref: OPSEXP-18962

Ensure backward compatibility.
Tested backward compat by locally running helm template rendition and unittest for acs-deployment 

Created OPSEXP-2227 OPSEXP-2228 to deprecate and remove old names