### PR TITLE
OPSEXP-2242: make repository secrets optional

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 0.1.0-alpha.9
+version: 0.1.0-alpha.10
 appVersion: 23.1.0-A21
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -1,6 +1,6 @@
 # alfresco-repository
 
-![Version: 0.1.0-alpha.9](https://img.shields.io/badge/Version-0.1.0--alpha.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.1.0-A21](https://img.shields.io/badge/AppVersion-23.1.0--A21-informational?style=flat-square)
+![Version: 0.1.0-alpha.10](https://img.shields.io/badge/Version-0.1.0--alpha.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.1.0-A21](https://img.shields.io/badge/AppVersion-23.1.0--A21-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 
@@ -117,7 +117,7 @@ environment:
 | configuration.messageBroker.url | string | `nil` | Message Broker URL |
 | configuration.messageBroker.username | string | `nil` | Username to authenticate to the message broker |
 | configuration.repository.existingConfigMap | string | `nil` | a configmap containing the "alfresco-global.properties" key populated with actual Alfresco repository properties |
-| configuration.repository.existingSecrets | list | `[{"key":"license.lic","name":"repository-secrets","purpose":"acs-license"}]` | A list of secrets to make available to the repository as env vars. This list can contain special secrets marked with predifined `purpose`: `acs-license` to pass license as a secret or subsystems:*:* to configure an Alfresco subsystem. See [Configuring Alfresco Subsystem](#configuring-alfresco-subsystems) for more details. |
+| configuration.repository.existingSecrets | list | `[{"key":"license.lic","name":"repository-secrets","purpose":"acs-license"}]` | A list of secrets to make available to the repository as env vars. This list can contain special secrets marked with predifined `purpose`: `acs-license` to pass license as a secret or subsystems:*:* to configure an Alfresco subsystem. See [Configuring Alfresco Subsystem](./docs/subsystems.md) for more details. |
 | configuration.search.existingConfigMap.keys.flavor | string | `"SEARCH_FLAVOR"` | configmap key where to find the search engine used |
 | configuration.search.existingConfigMap.keys.host | string | `"SEARCH_HOST"` | configmap key where to find the hostname part of the search URL. The configmap may leverage the alfresco-repository.solr.cm named template to auto-generate it from the sole url parameter. |
 | configuration.search.existingConfigMap.keys.port | string | `"SEARCH_PORT"` | configmap key where to find the port part of the search URL. The configmap may leverage the alfresco-repository.solr.cm named template to auto-generate it from the sole url parameter. |

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
                   key: {{ .Values.configuration.db.existingSecret.keys.username }}
           {{- range .Values.configuration.repository.existingSecrets }}
             {{- if not (or (eq "acs-license" .purpose) (hasPrefix "subsystems:" (.purpose | default ""))) }}
-              {{- $repoSecretsKeyRef := dict "name" .name "key" .key }}
+              {{- $repoSecretsKeyRef := dict "name" .name "key" .key "optional" true }}
               {{- $repoSecretsEnv:= dict "name" .key "valueFrom" (dict "secretKeyRef" $repoSecretsKeyRef) }}
               {{- list $repoSecretsEnv | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/alfresco-repository/tests/deployment_test.yaml
+++ b/charts/alfresco-repository/tests/deployment_test.yaml
@@ -161,6 +161,7 @@ tests:
               secretKeyRef:
                 key: MYSECRETVAR
                 name: mysecret
+                optional: true
         template: deployment.yaml
 
   - it: should render default DATABASE URL

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -28,7 +28,7 @@ configuration:
     # This list can contain special secrets marked with predifined `purpose`:
     # `acs-license` to pass license as a secret or subsystems:*:* to configure
     # an Alfresco subsystem. See [Configuring Alfresco
-    # Subsystem](#configuring-alfresco-subsystems) for more details.
+    # Subsystem](./docs/subsystems.md) for more details.
     existingSecrets:
       - name: repository-secrets
         key: license.lic


### PR DESCRIPTION
Ref: OPSEXP-2242: Needed in order to pass sensitive data (liked to a specific feature or config, e.g. smtp password) from a parent chart without checking whether the eature is enabled in subchart.
Open to discussion.