### PR TITLE
OPSEXP-2298: provide common templates to build activemq configmap

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 3.0.0-alpha.2
+version: 3.0.0-alpha.3
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 3.0.0-alpha.2](https://img.shields.io/badge/Version-3.0.0--alpha.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.0.0-alpha.3](https://img.shields.io/badge/Version-3.0.0--alpha.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-activemq.tpl
+++ b/charts/alfresco-common/templates/_helpers-activemq.tpl
@@ -1,4 +1,28 @@
 {{/*
+Validate ActiveMQ has a failover transport URL
+
+Usage: include "alfresco-common.activemq.url.valid" "URL"
+
+*/}}
+{{- define "alfresco-common.activemq.url.valid" -}}
+{{- if hasPrefix "failover:(" . }}
+  {{- . }}
+{{- else -}}
+  {{- printf "failover:(%s)" . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Render ActiveMQ broker configmap
+
+Usage: include "alfresco-common.activemq.cm" "URL"
+
+*/}}
+{{- define "alfresco-common.activemq.cm" -}}
+  BROKER_URL: {{ template "alfresco-common.activemq.url.valid" . }}
+{{- end -}}
+
+{{/*
 Provide generic ActiveMQ env vars
 
 Usage: include "alfresco-common.activemq.env" ""

--- a/charts/alfresco-common/templates/_helpers.tpl
+++ b/charts/alfresco-common/templates/_helpers.tpl
@@ -1,9 +1,0 @@
-{{- define "content-services.shortname" -}}
-{{- $name := (.Values.NameOverride | default "alfresco-cs") -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "alfresco.shortname" -}}
-{{- $name := (.Values.NameOverride | default "alfresco-") -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}


### PR DESCRIPTION
Ref: OPSEXP-2298
Needed for search enterprise chart (and future) others to avoid/reduce duplication