### PR TITLE
OPSEXP-2298: fixup search ernterprise chart - 3.0.0-alpha.4

### DIFF
--- a/charts/alfresco-search-enterprise/Chart.yaml
+++ b/charts/alfresco-search-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-enterprise
 description: A Helm chart for deploying Alfresco Elasticsearch connector
 type: application
-version: 3.0.0-alpha.3
+version: 3.0.0-alpha.4
 appVersion: 3.3.1
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -1,6 +1,6 @@
 # alfresco-search-enterprise
 
-![Version: 3.0.0-alpha.3](https://img.shields.io/badge/Version-3.0.0--alpha.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.1](https://img.shields.io/badge/AppVersion-3.3.1-informational?style=flat-square)
+![Version: 3.0.0-alpha.4](https://img.shields.io/badge/Version-3.0.0--alpha.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.1](https://img.shields.io/badge/AppVersion-3.3.1-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Elasticsearch connector
 

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -87,11 +87,11 @@ spec:
                   name: {{ $repoCm }}
                   key: {{ .Values.reindexing.repository.existingConfigMap.keys.url }}
           command: [ "/bin/sh","-c" ]
-          # Delay running the reindexing to give Alfresco Repository a chance to fully initialise
+          # Delay running the reindexing to give Alfresco Repository a chance to initialise its database
           args:
             - |
-              while [ $(curl -sw '%{http_code}' $(REPOSITORY_URL)/api/-default-/public/alfresco/versions/1/probes/-ready- -o /dev/null) -ne 200 ]
-              do echo 'Waiting for the Alfresco Repository...'
+              while [ $(curl -sw '%{http_code}' ${REPOSITORY_URL}/api/-default-/public/alfresco/versions/1/probes/-ready- -o /dev/null) -ne 200 ]
+              do echo "Waiting for the Alfresco repository to come up at $REPOSITORY_URL ..."
                 sleep 5
               done
               echo 'Alfresco is ready, delay reindexing to give a chance to fully initialise.'


### PR DESCRIPTION
Ref: OPSEXP-2298

looks like the `$(VAR)` notation in `spec.template.spec.containers[].args` does not work in shell and just creates a subshell instead (as it would in a regular shell env).
Tricked by https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config