### PR TITLE
OPSEXP-2297: change alfresco-common.db.port named template param to a single str

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 3.0.0-alpha.3
+version: 3.0.0-alpha.4
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 3.0.0-alpha.3](https://img.shields.io/badge/Version-3.0.0--alpha.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.0.0-alpha.4](https://img.shields.io/badge/Version-3.0.0--alpha.4-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-jdbc.tpl
+++ b/charts/alfresco-common/templates/_helpers-jdbc.tpl
@@ -102,15 +102,15 @@ Usage: include "alfresco-common.db.hostname" "URL"
 {{/*
 Provide database port from JDBC URL
 
-Usage: include "alfresco-common.db.port" (dict "url" "someurl")
+Usage: include "alfresco-common.db.port" "URL"
 
 */}}
 {{- define "alfresco-common.db.port" -}}
-{{- $socket := (index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "host") }}
+{{- $socket := (index (include "alfresco-common.jdbc.parser" . | fromJson) "jdbc" "host") }}
 {{- if gt ($socket | splitList ":" | len) 1 }}
   {{- $socket | splitList ":" | last }}
 {{- else }}
-  {{- template "alfresco-common.db.default.port" (index (include "alfresco-common.jdbc.parser" .url | fromJson) "jdbc" "scheme") }}
+  {{- template "alfresco-common.db.default.port" (index (include "alfresco-common.jdbc.parser" . | fromJson) "jdbc" "scheme") }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Ref: OPSEXP-2297

That function so far is only used in `alfresco-repository` chart (PR coming)