### PR TITLE
added podannotations for search-services

### DIFF
--- a/charts/alfresco-search-service/templates/deployment.yaml
+++ b/charts/alfresco-search-service/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "alfresco-search-service.fullname" . }}-solr
         release: {{ .Release.Name }}


### PR DESCRIPTION
we use podAnnotations in the 'charts' so would like to have these in all chart, but for now atleast in search-services.