### PR TITLE
missing component search on search-services deployment

### DIFF
--- a/charts/alfresco-search-service/templates/deployment.yaml
+++ b/charts/alfresco-search-service/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
         app: {{ template "alfresco-search-service.fullname" . }}-solr
         release: {{ .Release.Name }}
+        component: search
     spec:
     {{- include "component-pod-security-context" .Values | indent 4 }}
     {{- with .Values.affinity }}


### PR DESCRIPTION
In the pod labels, search is missing the component search.

Which other deployment have, like transformers for all the tansformer pods.

![image](https://github.com/Alfresco/alfresco-helm-charts/assets/1477763/9ca42000-c606-4077-b042-c1da4a5894c2)

![image](https://github.com/Alfresco/alfresco-helm-charts/assets/1477763/d04dcf41-2d18-409e-8f4b-869574a0fd46)

This time through my personal github account 👍 