### PR TITLE
OPSEXP-2435 Fix nodeSelector configuration in alfresco-repository

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 23.1.1
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -1,6 +1,6 @@
 # alfresco-repository
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.1.1](https://img.shields.io/badge/AppVersion-23.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.1.1](https://img.shields.io/badge/AppVersion-23.1.1-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -22,8 +22,6 @@ spec:
     spec:
       serviceAccountName: {{ include "alfresco-repository.serviceAccountName" . }}
       {{- include "alfresco-common.component-pod-security-context" .Values | indent 4 }}
-      nodeSelector:
-        {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- include "alfresco-common.imagePullSecrets" . | indent 6 }}
       initContainers:
         - name: wait-db-ready
@@ -221,7 +219,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/charts/alfresco-repository/tests/deployment_test.yaml
+++ b/charts/alfresco-repository/tests/deployment_test.yaml
@@ -206,3 +206,14 @@ tests:
           path: spec.template.spec.containers
           count: 2
         template: deployment.yaml
+
+  - it: should allow setting nodeSelector properly
+    values: *test_values
+    set:
+      nodeSelector:
+        node_label: node_value
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.node_label
+          value: node_value
+        template: deployment.yaml


### PR DESCRIPTION
Ref: OPSEXP-2435

```
helm template . --set alfresco-repository.nodeSelector.test=value
Error: YAML parse error on alfresco-content-services/charts/alfresco-repository/templates/deployment.yaml: error converting YAML to JSON: yaml: line 248: mapping values are not allowed in this context

Use --debug flag to render out invalid YAML
```