### PR TITLE
OPSEXP-2291 Repository secret should be optional in search service chart

### DIFF
--- a/charts/alfresco-search-service/Chart.yaml
+++ b/charts/alfresco-search-service/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 name: alfresco-search-service
 sources:
   - https://github.com/Alfresco/alfresco-helm-charts
-version: 3.0.0-alpha.0
+version: 3.0.0-alpha.1
 appVersion: 2.0.8.2
 dependencies:
   - name: alfresco-insight-zeppelin

--- a/charts/alfresco-search-service/README.md
+++ b/charts/alfresco-search-service/README.md
@@ -1,6 +1,6 @@
 # alfresco-search-service
 
-![Version: 3.0.0-alpha.0](https://img.shields.io/badge/Version-3.0.0--alpha.0-informational?style=flat-square) ![AppVersion: 2.0.8.2](https://img.shields.io/badge/AppVersion-2.0.8.2-informational?style=flat-square)
+![Version: 3.0.0-alpha.1](https://img.shields.io/badge/Version-3.0.0--alpha.1-informational?style=flat-square) ![AppVersion: 2.0.8.2](https://img.shields.io/badge/AppVersion-2.0.8.2-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Search Service
 

--- a/charts/alfresco-search-service/templates/deployment.yaml
+++ b/charts/alfresco-search-service/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
                 secretKeyRef:
                   name: {{ .existingSecret.name | default (include "alfresco-search-service.repository-config.name" $) }}
                   key: {{ .existingSecret.keys.sharedSecret }}
+                  optional: true
             - name: SOLR_ALFRESCO_HOST
               valueFrom:
                 configMapKeyRef:

--- a/charts/alfresco-search-service/tests/deployment_test.yaml
+++ b/charts/alfresco-search-service/tests/deployment_test.yaml
@@ -13,29 +13,11 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-solr
 
-  - it: should render cpu and memory limits
+  - it: should render annotations and environments
     values: *testvalues
     set:
       podAnnotations: &annotated
         kubernetes.io/description: Unit testing
-      environment:
-        someother: value
-    template: deployment.yaml
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].resources
-          value:
-            requests:
-              cpu: "0.50"
-              memory: "1200Mi"
-            limits:
-              cpu: "4"
-              memory: "2000Mi"
-
-  - it: should render annotations and environments
-    values: *testvalues
-    set:
-      podAnnotations: *annotated
       podLabels:
         a_label: true
       environment:
@@ -49,6 +31,15 @@ tests:
           path: spec.template.metadata.labels
           content:
             a_label: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOLR_ALFRESCO_SECURECOMMS_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: SOLR_ALFRESCO_SECURECOMMS_SECRET
+                name: RELEASE-NAME-solr-repository-config
+                optional: true
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -87,7 +78,21 @@ tests:
               persistentVolumeClaim:
                 claimName: solr-default-pvc
 
-  - it: should render cpu and memory limits
+  - it: should render default cpu and memory limits
+    values: *testvalues
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: "0.50"
+              memory: "1200Mi"
+            limits:
+              cpu: "4"
+              memory: "2000Mi"
+
+  - it: should render custom cpu and memory limits
     set:
       resources:
         requests:
@@ -96,6 +101,7 @@ tests:
         limits:
           cpu: "4"
           memory: "3000Mi"
+    template: deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources
@@ -106,4 +112,3 @@ tests:
             limits:
               cpu: "4"
               memory: "3000Mi"
-        template: deployment.yaml


### PR DESCRIPTION
Mainly useful for older search/acs versions which doesn't support preshared secret.

Ref: OPSEXP-2291