### PR TITLE
OPSEXP-2440: alfresco-common - remove trailing slash from SFS_URL

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 3.1.0
+version: 3.1.1
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -1,6 +1,6 @@
 # alfresco-common
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.1.1](https://img.shields.io/badge/Version-3.1.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-ats.tpl
+++ b/charts/alfresco-common/templates/_helpers-ats.tpl
@@ -21,5 +21,5 @@ Usage: include "alfresco-common.sfs.fullurl" "URL"
 {{- define "alfresco-common.sfs.fullurl" -}}
 {{- $scheme := include "alfresco-common.url.scheme" . }}
 {{- $host := include "alfresco-common.url.host" . }}
-{{- printf "%s://%s/alfresco/api/-default-/private/sfs/versions/1/file/" $scheme $host }}
+{{- printf "%s://%s/alfresco/api/-default-/private/sfs/versions/1/file" $scheme $host }}
 {{- end -}}


### PR DESCRIPTION
Ref: OPSEXP-2440
Other charts lived nicely with the trailing `/`but ai-transformer complains with 404 errors