### PR TITLE
OPSEXP-2488 Configurable ingress class in repository chart

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 0.1.3
+version: 0.2.0
 appVersion: 23.1.1
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -81,11 +81,8 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | image.repository | string | `"quay.io/alfresco/alfresco-content-repository"` |  |
 | image.tag | string | `"23.1.1"` |  |
 | imagePullSecrets | list | `[]` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/affinity" | string | `"cookie"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"5g"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-hash" | string | `"sha1"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-name" | string | `"alfrescoRepo"` |  |
-| ingress.className | string | `"nginx"` | provide annotations for nginx ingress (no toher ingress is supported at that point) |
+| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/affinity":"cookie","nginx.ingress.kubernetes.io/proxy-body-size":"5g","nginx.ingress.kubernetes.io/session-cookie-hash":"sha1","nginx.ingress.kubernetes.io/session-cookie-name":"alfrescoRepo"}` | provide annotations for nginx ingress (no toher ingress is supported at that point) |
+| ingress.className | string | `"nginx"` | supported ingress class |
 | ingress.enabled | bool | `true` | Toggle ingress |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -1,6 +1,6 @@
 # alfresco-repository
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.1.1](https://img.shields.io/badge/AppVersion-23.1.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.1.1](https://img.shields.io/badge/AppVersion-23.1.1-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 
@@ -81,7 +81,11 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | image.repository | string | `"quay.io/alfresco/alfresco-content-repository"` |  |
 | image.tag | string | `"23.1.1"` |  |
 | imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/affinity":"cookie","nginx.ingress.kubernetes.io/proxy-body-size":"5g","nginx.ingress.kubernetes.io/session-cookie-hash":"sha1","nginx.ingress.kubernetes.io/session-cookie-name":"alfrescoRepo"}` | provide annotations for nginx ingress (no toher ingress is supported at that point) |
+| ingress.annotations."nginx.ingress.kubernetes.io/affinity" | string | `"cookie"` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"5g"` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-hash" | string | `"sha1"` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/session-cookie-name" | string | `"alfrescoRepo"` |  |
+| ingress.className | string | `"nginx"` | provide annotations for nginx ingress (no toher ingress is supported at that point) |
 | ingress.enabled | bool | `true` | Toggle ingress |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |

--- a/charts/alfresco-repository/templates/ingress.yaml
+++ b/charts/alfresco-repository/templates/ingress.yaml
@@ -2,20 +2,9 @@
 {{- $fullName := include "alfresco-repository.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{/*
-We only support nginx ingress for now: https://alfresco.atlassian.net/browse/OPSEXP-131
-so forcibly set the ingress.class annotation to nginx for pre 1.18 k8s
+We only support latest apiVersion which is stable now.
 */}}
-{{- if not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  {{- $_ := unset .Values.ingress.annotations "kubernetes.io/ingress.class" }}
-  {{- $_ = set .Values.ingress.annotations "kubernetes.io/ingress.class" "nginx" }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -26,16 +15,7 @@ metadata:
     {{- include "alfresco-common.nginx.annotations" .Values }}
     {{- include "alfresco-common.nginx.secure.annotations" .Values }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-{{/*
-We only support nginx ingress for now: https://alfresco.atlassian.net/browse/OPSEXP-131
-so forcibly set the ingressClassName to nginx for post 1.18 k8s
-*/}}
-  {{- if (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: nginx
-  {{- end }}
+  ingressClassName: {{ .Values.ingress.className | default "nginx" }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -53,19 +33,14 @@ so forcibly set the ingressClassName to nginx for post 1.18 k8s
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if .pathType }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/alfresco-repository/templates/ingress.yaml
+++ b/charts/alfresco-repository/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "alfresco-common.nginx.annotations" .Values }}
     {{- include "alfresco-common.nginx.secure.annotations" .Values }}
 spec:
-  ingressClassName: {{ .Values.ingress.className | default "nginx" }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/alfresco-repository/tests/ingress_test.yaml
+++ b/charts/alfresco-repository/tests/ingress_test.yaml
@@ -21,25 +21,6 @@ tests:
   - it: should sanitize ingress
     capabilities:
       majorVersion: 1
-      minorVersion: 17
-    set:
-      ingress:
-        annotations:
-          kubernetes.io/ingress.class: myfancyClass
-          nginx.ingress.kubernetes.io/server-snippet: listen 6666;
-    asserts:
-      - notMatchRegex:
-          path: metadata.annotations['nginx.ingress.kubernetes.io/server-snippet']
-          pattern: listen 6666;
-        template: ingress.yaml
-      - equal:
-          path: metadata.annotations['kubernetes.io/ingress.class']
-          value: nginx
-        template: ingress.yaml
-
-  - it: should sanitize ingress
-    capabilities:
-      majorVersion: 1
       minorVersion: 19
     set:
       ingress:

--- a/charts/alfresco-repository/tests/ingress_test.yaml
+++ b/charts/alfresco-repository/tests/ingress_test.yaml
@@ -31,10 +31,10 @@ tests:
 
   - it: should render default rules section
     asserts:
-      - equal: 
+      - equal:
           path: spec.rules
           value:
-            - host: 
+            - host:
               http:
                 paths:
                   - path: /
@@ -50,7 +50,7 @@ tests:
                       service:
                         name: RELEASE-NAME-alfresco-repository
                         port:
-                          number: 80         
+                          number: 80
 
   - it: should render tls section with specified values
     set:

--- a/charts/alfresco-repository/tests/ingress_test.yaml
+++ b/charts/alfresco-repository/tests/ingress_test.yaml
@@ -19,9 +19,6 @@ tests:
         template: ingress.yaml
 
   - it: should sanitize ingress
-    capabilities:
-      majorVersion: 1
-      minorVersion: 19
     set:
       ingress:
         annotations:

--- a/charts/alfresco-repository/tests/ingress_test.yaml
+++ b/charts/alfresco-repository/tests/ingress_test.yaml
@@ -12,11 +12,9 @@ tests:
             location ~ ^/.*/proxy/.*/api/solr/.*$ {return 403;}
             location ~ ^/.*/-default-/proxy/.*/api/.*$ {return 403;}
             location ~ ^/.*/s/prometheus$ {return 403;}
-        template: ingress.yaml
       - equal:
           path: spec.ingressClassName
           value: nginx
-        template: ingress.yaml
 
   - it: should sanitize ingress
     set:
@@ -27,8 +25,44 @@ tests:
       - notMatchRegex:
           path: metadata.annotations['nginx.ingress.kubernetes.io/server-snippet']
           pattern: listen 6666;
-        template: ingress.yaml
       - equal:
           path: spec.ingressClassName
           value: nginx
-        template: ingress.yaml
+
+  - it: should render default rules section
+    asserts:
+      - equal: 
+          path: spec.rules
+          value:
+            - host: 
+              http:
+                paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: RELEASE-NAME-alfresco-repository
+                        port:
+                          number: 80
+                  - path: /api-explorer
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: RELEASE-NAME-alfresco-repository
+                        port:
+                          number: 80         
+
+  - it: should render tls section with specified values
+    set:
+      ingress:
+        tls:
+         - secretName: chart-example-tls
+           hosts:
+             - chart-example.local
+    asserts:
+      - equal:
+          path: spec.tls
+          value:
+            - hosts:
+                - "chart-example.local"
+              secretName: chart-example-tls

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -214,6 +214,7 @@ ingress:
   enabled: true
   # -- provide annotations for nginx ingress (no toher ingress is supported at
   # that point)
+  className: nginx
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 5g
     nginx.ingress.kubernetes.io/affinity: "cookie"

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -214,12 +214,13 @@ ingress:
   enabled: true
   # -- provide annotations for nginx ingress (no toher ingress is supported at
   # that point)
-  className: nginx
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 5g
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "alfrescoRepo"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+  # -- supported ingress class
+  className: nginx
   hosts:
     - paths:
         - path: /


### PR DESCRIPTION
- Drop support for previous apiVersions

Ref: [OPSEXP-2488](https://alfresco.atlassian.net/browse/OPSEXP-2488)

[OPSEXP-2488]: https://alfresco.atlassian.net/browse/OPSEXP-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ