### PR TITLE
Fixup testing multiple charts

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
 
 jobs:
   lint-test:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -96,9 +96,3 @@ jobs:
           ct install --config ct-install.yaml
           --namespace "$INSTALL_NAMESPACE"
           $TEST_ALL_CHARTS_ARG
-          --skip-clean-up
-
-      - name: Debug on failure
-        if: failure()
-        run: |
-          kubectl --namespace "$INSTALL_NAMESPACE" get svc


### PR DESCRIPTION
* `--skip-clean-up` was added to further debug svc creation which is not logged by `ct` on failure, but I don't see any other ways to make it work reliably when testing multiple charts at once (activemq pvc will clash and we don't really want to install all charts together)
* enable triggering the workflow by just attaching a label