### PR TITLE
OPSEXP-2504 Avoid setting rollingUpdate when unnecessary in filestore

### DIFF
--- a/charts/alfresco-transform-service/Chart.yaml
+++ b/charts/alfresco-transform-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-transform-service
 description: A Helm chart for deploying Alfresco Transform Services
 type: application
-version: 2.1.0-alpha.0
+version: 2.1.0-alpha.1
 appVersion: 4.1.3
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-transform-service/README.md
+++ b/charts/alfresco-transform-service/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-transform-service
 
-![Version: 2.1.0-alpha.0](https://img.shields.io/badge/Version-2.1.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.3](https://img.shields.io/badge/AppVersion-4.1.3-informational?style=flat-square)
+![Version: 2.1.0-alpha.1](https://img.shields.io/badge/Version-2.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.3](https://img.shields.io/badge/AppVersion-4.1.3-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Transform Services
 

--- a/charts/alfresco-transform-service/templates/deployment-filestore.yaml
+++ b/charts/alfresco-transform-service/templates/deployment-filestore.yaml
@@ -12,8 +12,10 @@ spec:
       {{- include "alfresco-transform-service.filestore.selectorLabels" . | nindent 6 }}
   strategy:
     type: {{ .Values.filestore.strategy.type }}
+    {{- if eq .Values.filestore.strategy.type "RollingUpdate" }}
     rollingUpdate:
       {{- toYaml .Values.global.strategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/alfresco-transform-service/tests/deployment-filestore_test.yaml
+++ b/charts/alfresco-transform-service/tests/deployment-filestore_test.yaml
@@ -11,6 +11,12 @@ tests:
           path: spec.strategy.type
           value: RollingUpdate
         template: deployment-filestore.yaml
+      - equal:
+          path: spec.strategy.rollingUpdate
+          value:
+            maxSurge: 1
+            maxUnavailable: 0
+        template: deployment-filestore.yaml
   - it: should render overridden strategy type
     set:
       filestore:
@@ -20,4 +26,7 @@ tests:
       - equal:
           path: spec.strategy.type
           value: Recreate
+        template: deployment-filestore.yaml
+      - notExists:
+          path: spec.strategy.rollingUpdate
         template: deployment-filestore.yaml


### PR DESCRIPTION
```
 Error: INSTALLATION FAILED: 1 error occurred:
	* Deployment.apps "acs-filestore" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

OPSEXP-2504