### PR TITLE
Fix csrf.origin url join for share-config

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,7 +29,11 @@ jobs:
         run: |
           helm plugin install https://github.com/jtyr/kubeconform-helm --version v0.1.12
 
+      - name: Checkout branch/fork
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: Run pre-commit
         uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@a288b9efdaa50413573b2e130896d906478b8e50 # v5.31.0
         with:
           auto-commit: "true"
+          skip_checkout: "true"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,9 +29,6 @@ jobs:
         run: |
           helm plugin install https://github.com/jtyr/kubeconform-helm --version v0.1.12
 
-      - name: Checkout branch/fork
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
       - name: Run pre-commit
         uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@a288b9efdaa50413573b2e130896d906478b8e50 # v5.31.0
         with:

--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 3.1.3
+version: 3.1.4
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-common
 
-![Version: 3.1.3](https://img.shields.io/badge/Version-3.1.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.1.4](https://img.shields.io/badge/Version-3.1.4-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies

--- a/charts/alfresco-common/templates/_helpers-url.tpl
+++ b/charts/alfresco-common/templates/_helpers-url.tpl
@@ -46,7 +46,7 @@ Usage: include "alfresco-common.csrf.origin" $
   {{- $known_url := urlJoin (dict "host" $parsed_url.host "scheme" $parsed_url.scheme) }}
   {{- $csrf_origins = append $csrf_origins $known_url }}
 {{- end }}
-{{- $csrf_origins | join "," }}
+{{- $csrf_origins | join "\\|" }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
According to the share-config.xml CSRF origins should be separated with  | and not ,