### PR TITLE
Increase the init container (busybox) memory limit

### DIFF
--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           resources:
             limits:
               cpu: "0.25"
-              memory: "10Mi"
+              memory: "12Mi"
           env:
             {{ include "alfresco-repository.db.env" . | indent 12 }}
           command:


### PR DESCRIPTION
With the CRI-O container runtime, the Alfresco repository wait-db init container (using busybox) can't start with a 10Mi memory limit. This error returned by Kubelet:
  Warning  Failed     4m38s (x12 over 6m52s)  kubelet            Error: set memory limit 10485760 too low; should be at least 12582912    

Increasing the limit from 10Mi to 12Mi fix the issue.
This issues is linked to https://github.com/cri-o/cri-o/pull/2263 and https://github.com/cri-o/cri-o/pull/2529

Context:
CRI-O: version: 1.29.1, git: 78e179ba8dd3ce462382a17049e8d1f770246af1(clean)
OS: Ubuntu 22.04.4 LTS
ACS version: 8.4.0
Kubernetes Cluster (1.29.6) installed with Kubespray (v2.25.0)

