### PR TITLE
OPSEXP-2654 Reindex job as configurable helm hook

### DIFF
--- a/charts/alfresco-search-enterprise/Chart.yaml
+++ b/charts/alfresco-search-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-enterprise
 description: A Helm chart for deploying Alfresco Elasticsearch connector
 type: application
-version: 4.1.0
+version: 4.2.0-alpha.0
 appVersion: 4.1.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-enterprise
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 4.2.0-alpha.0](https://img.shields.io/badge/Version-4.2.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Elasticsearch connector
 
@@ -81,6 +81,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | reindexing.db.username | string | `nil` | The username required to access the service |
 | reindexing.enabled | bool | `true` | Create the one-shot job to trigger the reindexing of repo contents |
 | reindexing.environment | object | `{}` |  |
+| reindexing.hookExecution | string | `"post-install"` | When to execute the reindexing job (e.g. `post-install` or `post-upgrade` or set to false to apply as a standard resource) |
 | reindexing.image.pullPolicy | string | `"IfNotPresent"` |  |
 | reindexing.image.repository | string | `"quay.io/alfresco/alfresco-elasticsearch-reindexing"` |  |
 | reindexing.image.tag | string | `"4.1.0"` |  |

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -95,6 +95,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | reindexing.resources.limits.memory | string | `"512Mi"` |  |
 | reindexing.resources.requests.cpu | string | `"0.5"` |  |
 | reindexing.resources.requests.memory | string | `"128Mi"` |  |
+| reindexing.ttlSecondsAfterFinished | int | `3600` | Time to live for the job after it has finished to run |
 | resources.limits.cpu | string | `"2"` |  |
 | resources.limits.memory | string | `"2048Mi"` |  |
 | resources.requests.cpu | string | `"0.5"` |  |

--- a/charts/alfresco-search-enterprise/ci/default-values.yaml
+++ b/charts/alfresco-search-enterprise/ci/default-values.yaml
@@ -4,7 +4,7 @@ reindexing:
   # a db would be required but helm install won't wait for the job to be ready
   enabled: true
   # ... but only if it's not defined as an hook
-  hookExecution: post-install
+  hookExecution: false
   repository:
     url: http://repository
   db:

--- a/charts/alfresco-search-enterprise/ci/default-values.yaml
+++ b/charts/alfresco-search-enterprise/ci/default-values.yaml
@@ -1,8 +1,10 @@
 # avoid too long resource names being truncated and conflicting
 nameOverride: aesc
 reindexing:
-  # requires postgres database at startup
+  # a db would be required but helm install won't wait for the job to be ready
   enabled: true
+  # ... but only if it's not defined as an hook
+  hookExecution: post-install
   repository:
     url: http://repository
   db:

--- a/charts/alfresco-search-enterprise/ci/default-values.yaml
+++ b/charts/alfresco-search-enterprise/ci/default-values.yaml
@@ -1,9 +1,9 @@
 # avoid too long resource names being truncated and conflicting
 nameOverride: aesc
 reindexing:
-  # a db would be required but helm install won't wait for the job to be ready
+  # A database is required for reindexing, but Helm does not wait for the job to complete during installation.
   enabled: true
-  # ... but only if it's not defined as an hook
+  # Allows tests to pass, otherwise when reindexing job is run as hook, installation will fail.
   hookExecution: false
   repository:
     url: http://repository

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -10,6 +10,7 @@ metadata:
     "helm.sh/hook": {{ . | quote }}
     {{- end }}
 spec:
+  ttlSecondsAfterFinished: {{ .Values.reindexing.ttlSecondsAfterFinished }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -2,9 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "alfresco-search-enterprise.fullname" . }}-reindexing
+  name: {{ include "alfresco-search-enterprise.fullname" . }}-reindexing{{ if eq (.Values.reindexing.hookExecution | default "") "post-upgrade" }}-{{ randAlphaNum 5 | lower }}{{ end }}
   labels:
     {{- include "alfresco-search-enterprise.labels" $ | nindent 4 }}
+  annotations:
+    {{- with .Values.reindexing.hookExecution }}
+    "helm.sh/hook": {{ . | quote }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
+++ b/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
@@ -157,3 +157,37 @@ tests:
               configMapKeyRef:
                 name: mycm
                 key: REPO_URL
+
+  - it: has default hook annotation
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            "helm.sh/hook": "post-install"
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-alfresco-search-enterprise-reindexing
+
+  - it: has changed hook annotation
+    set:
+      reindexing:
+        hookExecution: post-upgrade
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            "helm.sh/hook": "post-upgrade"
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME-alfresco-search-enterprise-reindexing-[a-z0-9]{5}
+
+  - it: has no hook annotation when disabled
+    set:
+      reindexing:
+        hookExecution: false
+    asserts:
+      - notExists:
+          path: metadata.annotations."helm.sh/hook"
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-alfresco-search-enterprise-reindexing

--- a/charts/alfresco-search-enterprise/values.yaml
+++ b/charts/alfresco-search-enterprise/values.yaml
@@ -187,6 +187,9 @@ reindexing:
     pullPolicy: IfNotPresent
   pathIndexingEnabled: true
   environment: {}
+  # -- When to execute the reindexing job (e.g. `post-install` or `post-upgrade`
+  # or set to false to apply as a standard resource)
+  hookExecution: post-install
   repository:
     # -- URL of the Alfresco repository
     url: null

--- a/charts/alfresco-search-enterprise/values.yaml
+++ b/charts/alfresco-search-enterprise/values.yaml
@@ -190,6 +190,8 @@ reindexing:
   # -- When to execute the reindexing job (e.g. `post-install` or `post-upgrade`
   # or set to false to apply as a standard resource)
   hookExecution: post-install
+  # -- Time to live for the job after it has finished to run
+  ttlSecondsAfterFinished: 3600
   repository:
     # -- URL of the Alfresco repository
     url: null


### PR DESCRIPTION
OPSEXP-2654

The new default is to run it as post-install hook so it won't rerun on each upgrade if was cleaned up.

Optionally `reindexing.hookExecution` could be set to `post-upgrade` so that could mimic an on-demand execution by triggering together with an upgrade. In this case the job name got a rand appended to avoid clashes.

It can be set to false to restore the previous behavior.