### PR TITLE
OPSEXP-2890: add ACS Audit component to the target matrix

### DIFF
--- a/updatecli-matrix-targets.yaml
+++ b/updatecli-matrix-targets.yaml
@@ -109,6 +109,13 @@ matrix:
       helm_target: charts/alfresco-repository/values.yaml
       helm_key: $.image.tag
       helm_update_appVersion: true
+    acs-audit:
+      version:
+      pattern:
+      image:
+      helm_target: charts/alfresco-audit-storage/values.yaml
+      helm_key: $.image.tag
+      helm_update_appVersion: true
     activemq:
       version:
       pattern:


### PR DESCRIPTION
Ref: OPSEXP-2890
Tested in https://github.com/Alfresco/alfresco-helm-charts/actions/runs/11913804711