### PR TITLE
OPSEXP-3128 Fixup compatiblity with nginx-unprivileged images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: kubeconform-helm
         alias: kubeconform-helm-min
-        name: "Kubeconform Helm - min k8s version" # most older EKS version still in extended support
+        name: "Kubeconform Helm - min k8s version" # the oldest EKS version still in extended support
         files: ^charts/[^/]+/(\.kubeconform|\.helmignore|templates/NOTES.txt|.*\.(ya?ml|json|tpl))$
         args:
           - --kubernetes-version=1.28.15 # eks.34 https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: kubeconform-helm
         alias: kubeconform-helm-min
-        name: "Kubeconform Helm - min k8s version (most recent EKS version inextended support)"
+        name: "Kubeconform Helm - min k8s version" # most older EKS version still in extended support
         files: ^charts/[^/]+/(\.kubeconform|\.helmignore|templates/NOTES.txt|.*\.(ya?ml|json|tpl))$
         args:
           - --kubernetes-version=1.28.15 # eks.34 https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html
@@ -30,7 +30,7 @@ repos:
     rev: v0.1.17
     hooks:
       - id: kubeconform-helm
-        name: "Kubeconform Helm - current k8s version (current as in currently supported by both Alfresco & AWS)"
+        name: "Kubeconform Helm - current k8s version" # current as in currently supported by both Alfresco & AWS
         files: ^charts/[^/]+/(\.kubeconform|\.helmignore|templates/NOTES.txt|.*\.(ya?ml|json|tpl))$
         args:
           - --kubernetes-version=1.31.4 # eks.17 https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html

--- a/charts/alfresco-adf-app/Chart.yaml
+++ b/charts/alfresco-adf-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-adf-app
 description: A generic Alfresco Development Framework Helm chart for Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: alfresco-common
     version: 4.0.0

--- a/charts/alfresco-adf-app/README.md
+++ b/charts/alfresco-adf-app/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-adf-app
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic Alfresco Development Framework Helm chart for Kubernetes
 
@@ -46,8 +46,9 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
+| podSecurityContext.runAsGroup | int | `101` |  |
 | podSecurityContext.runAsNonRoot | bool | `true` |  |
-| podSecurityContext.runAsUser | int | `33000` |  |
+| podSecurityContext.runAsUser | int | `101` | For compatibility with nginxinc/nginx-unprivileged used by adf apps |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
 | readinessProbe.httpGet.port | string | `"http"` |  |

--- a/charts/alfresco-adf-app/values.yaml
+++ b/charts/alfresco-adf-app/values.yaml
@@ -24,7 +24,9 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:
-  runAsUser: 33000
+  # -- For compatibility with nginxinc/nginx-unprivileged used by adf apps
+  runAsUser: 101
+  runAsGroup: 101
   runAsNonRoot: true
 
 securityContext: {}


### PR DESCRIPTION
Bumping charts in https://github.com/Alfresco/alfresco-dockerfiles-bakery/pull/153 exposed this breaking change

uid/gid should match the ones of the upstream `nginxinc/nginx-unprivileged` image so the entrypoint customization script works as expected.

OPSEXP-3128