### PR TITLE
alfresco-repository: conditionally remove rollingUpdate block when strategy.type=Recreate

### DIFF
--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -12,7 +12,11 @@ spec:
     matchLabels:
       {{- include "alfresco-repository.selectorLabels" . | nindent 6 }}
   strategy:
-    {{- toYaml (.Values.strategy | default .Values.global.strategy) | nindent 4 }}
+    type: {{ coalesce .Values.strategy.type .Values.global.strategy.type | default "RollingUpdate" }}
+    {{- if eq (coalesce .Values.strategy.type .Values.global.strategy.type | default "RollingUpdate") "RollingUpdate" }}
+    rollingUpdate:
+      {{- toYaml (coalesce .Values.strategy.rollingUpdate .Values.global.strategy.rollingUpdate) | nindent 6 }}
+    {{- end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
### Summary
This PR fixes a deployment failure when `strategy.type` is set to `Recreate`. Previously, the chart always included the `rollingUpdate` configuration, causing an error in Kubernetes (`spec.strategy.rollingUpdate` is invalid when `type: Recreate`) -> is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is `Recreate`

### What has changed
- The `strategy` block in `alfresco-repository` now conditionally includes the `rollingUpdate` section **only** if `strategy.type` (or the global fallback) is `"RollingUpdate"`.
- The implementation uses `coalesce` and a `default` to ensure a valid fallback strategy is always set.

### Why this is needed
Without this fix, users overriding the deployment strategy to `Recreate` face errors during deployment due to invalid manifest generation. This PR ensures that Helm only emits `rollingUpdate` fields if they are actually required.
I have exhaustively tested all possible alternatives, including:
- Setting `rollingUpdate` to `null`
- Setting `rollingUpdate` to `{}` (empty object)
- Setting `maxSurge` and `maxUnavailable` to `null`
- Explicitly removing `rollingUpdate` in values

### Testing
- Rendered the template locally via `helm template` to confirm that `rollingUpdate` is omitted when `strategy.type=Recreate`.
- Verified backward compatibility to ensure the chart defaults to `RollingUpdate` when no strategy is defined.

Thanks