### PR TITLE
OPSEXP-3225: allow mounting extra volumes in search enterprise

### DIFF
--- a/charts/alfresco-search-enterprise/Chart.yaml
+++ b/charts/alfresco-search-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-enterprise
 description: A Helm chart for deploying Alfresco Elasticsearch connector
 type: application
-version: 4.4.0
+version: 4.4.1
 appVersion: 5.0.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-enterprise
 
-![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
+![Version: 4.4.1](https://img.shields.io/badge/Version-4.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Elasticsearch connector
 

--- a/charts/alfresco-search-enterprise/docs/truststore.md
+++ b/charts/alfresco-search-enterprise/docs/truststore.md
@@ -1,0 +1,81 @@
+# Setting custom java truststore
+
+There multiple use cases where you may want to set a custom keystore or
+truststore. It can be because you need to interact with a third party service
+which uses a self-signed certificate or a prvite CA that is not shipped with
+the container. Or maybe the service you are trying to connect to uses a
+self-signed certificate and you want to trust it. In this case, you can
+create a custom truststore and set it in the container.
+
+## Create a custom truststore
+
+You can create a custom truststore on your local machine using the
+`keytool` command. The `keytool` command is part of the Java Development Kit (JDK)
+and is used to manage keystores and truststores. You can use the following
+command to create a new truststore and import a certificate into it:
+
+```bash
+keytool -importcert -file <path-to-certificate-file> -alias <alias-name> -keystore <path-to-truststore-file>
+```
+
+Where `<path-to-certificate-file>` is the path to the CA certificate or the
+self-signed certificate you want to trust, `<alias-name>` is a name you want
+to give to the certificate in the truststore, and `<path-to-truststore-file>`
+is the path to the truststore file you want to create.
+You will be prompted to enter a password for the truststore. You can use
+the default password `changeit` or leave it empty (Truststore usually contain
+public informations so it should not be a problem to not use a password).
+Also note that <path-to-truststore-file> can point to an already existing
+truststore file. We recommand using the default  `cacerts` truststore that
+comes with the JDK. This way, you can add your custom certificates to the
+default truststore and use it in your application.
+
+## Create a Kubernetes secret
+
+Once you have created the truststore, you can create a Kubernetes secret
+to store the truststore file. You can use the following command to create a
+Kubernetes secret:
+
+```bash
+kubectl create secret generic -n <namespace> <secret-name> \
+  --from-file=<path-to-truststore-file> \
+  --dry-run=client -o yaml
+```
+
+Where `<secret-name>` is the name you want to give to the secret and
+`<path-to-truststore-file>` is the path to the truststore file you created
+or updated in the previous step and `<namespace>` is the namespace where you
+want to create the secret (needs to be the same namespace where your pods are
+running).
+
+This will produce a YAML output you can then apply to your Kubernetes
+cluster or save to a file for applying later.
+
+## Mount the secret in the pod
+
+You can mount the secret in the pod by adding the following values to the
+Helm values file:
+
+```yaml
+extraVolumes:
+  - name: custom-truststore
+    secret:
+      secretName: <secret-name>
+extraVolumeMounts:
+  - name: custom-truststore
+    mountPath: /etc/ssl/certs/custom-truststore
+    subPath: <path-to-truststore-file>
+```
+
+Now you need to set the `JAVA_OPTS` environment variable to use the custom
+truststore. You can do this by adding the following values to the Helm
+values file:
+
+```yaml
+liveIndexing:
+  environment:
+    JAVA_OPTS: "-Djavax.net.ssl.trustStore=/etc/ssl/certs/custom-truststore"
+reindexing:
+  environment:
+    JAVA_OPTS: "-Djavax.net.ssl.trustStore=/etc/ssl/certs/custom-truststore"
+```

--- a/charts/alfresco-search-enterprise/docs/truststore.md
+++ b/charts/alfresco-search-enterprise/docs/truststore.md
@@ -6,7 +6,7 @@ grand_parent: Guides
 
 # Setting custom java truststore
 
-There multiple use cases where you may want to set a custom keystore or
+There are multiple use cases where you may want to set a custom keystore or
 truststore. It can be because you need to interact with a third party service
 which uses a self-signed certificate or a prvite CA that is not shipped with
 the container. Or maybe the service you are trying to connect to uses a

--- a/charts/alfresco-search-enterprise/docs/truststore.md
+++ b/charts/alfresco-search-enterprise/docs/truststore.md
@@ -55,7 +55,11 @@ want to create the secret (needs to be the same namespace where your pods are
 running).
 
 This will produce a YAML output you can then apply to your Kubernetes
-cluster or save to a file for applying later.
+cluster or save to a file for applying later with the command below:
+
+```bash
+kubectl apply -f <path-to-secret-file>
+```
 
 ## Mount the secret in the pod
 

--- a/charts/alfresco-search-enterprise/docs/truststore.md
+++ b/charts/alfresco-search-enterprise/docs/truststore.md
@@ -1,3 +1,9 @@
+---
+title: Truststore
+parent: Alfresco Search Enterprise
+grand_parent: Guides
+---
+
 # Setting custom java truststore
 
 There multiple use cases where you may want to set a custom keystore or

--- a/charts/alfresco-search-enterprise/templates/deployment.yaml
+++ b/charts/alfresco-search-enterprise/templates/deployment.yaml
@@ -15,9 +15,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/secret-broker: {{ include (print $.Template.BasePath "/secret-messagebroker.yaml") $ | sha256sum }}
-        checksum/secret-database: {{ include (print $.Template.BasePath "/secret-database.yaml") $ | sha256sum }}
-        checksum/secret-elasticsearch: {{ include (print $.Template.BasePath "/secret-elasticsearch.yaml") $ | sha256sum }}
       {{- with $.Values.podAnnotations }}
         {{- toYaml $ | nindent 8 }}
       {{- end }}

--- a/charts/alfresco-search-enterprise/templates/deployment.yaml
+++ b/charts/alfresco-search-enterprise/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}
           resources: {{- toYaml $.Values.resources | nindent 12 }}
+          {{- with coalesce $service.extraVolumeMounts $.Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -74,6 +78,10 @@ spec:
       {{- end }}
       {{- with $.Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with coalesce $service.extraVolumes $.Values.extraVolumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -75,6 +75,11 @@ spec:
               - name: http
                 containerPort: 8080
                 protocol: TCP
+          {{- with coalesce .Values.reindexing.extraVolumeMounts $.Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
       initContainers:
         - name: wait-for-repository
           {{- with .Values.reindexing.initcontainers.waitForRepository }}
@@ -112,6 +117,10 @@ spec:
       {{- end }}
       {{- with $.Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with coalesce .Values.reindexing.extraVolumes $.Values.extraVolumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{ end }}

--- a/charts/alfresco-search-enterprise/templates/statefulset-mediation.yaml
+++ b/charts/alfresco-search-enterprise/templates/statefulset-mediation.yaml
@@ -17,25 +17,24 @@ spec:
       {{- include "alfresco-common.imagePullSecrets" . | indent 6 }}
       {{- include "alfresco-common.component-pod-security-context" .Values | indent 4 }}
       containers:
-        {{- with .Values.liveIndexing.mediation }}
+      {{- with .Values.liveIndexing.mediation }}
         - name: {{ template "alfresco-search-enterprise.name" $ctx }}
           image: {{ .image.repository }}:{{ .image.tag }}
           imagePullPolicy: {{ .image.pullPolicy }}
-        {{- end }}
-          {{- include "alfresco-common.component-security-context" .Values | indent 8 }}
+          {{- include "alfresco-common.component-security-context" $.Values | indent 8 }}
           env:
-            {{- include "alfresco-search-enterprise.activemq.secret.env" . | nindent 12 }}
-            {{- include "alfresco-search-enterprise.activemq.cm.env" . | nindent 12 }}
-            {{- include "alfresco-common.spring.activemq.env" . | nindent 12 }}
-            {{- include "alfresco-search-enterprise.env" . | nindent 12 }}
+            {{- include "alfresco-search-enterprise.activemq.secret.env" $ | nindent 12 }}
+            {{- include "alfresco-search-enterprise.activemq.cm.env" $ | nindent 12 }}
+            {{- include "alfresco-common.spring.activemq.env" $ | nindent 12 }}
+            {{- include "alfresco-search-enterprise.env" $ | nindent 12 }}
             {{- $atsCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" ($.Values.nameOverride | default $.Chart.Name) "ats")) "Chart" $.Chart "Release" $.Release }}
-            {{- $ats_cm := coalesce .Values.ats.existingConfigMap.name (include "alfresco-search-enterprise.fullname" $atsCtx) }}
+            {{- $ats_cm := coalesce $.Values.ats.existingConfigMap.name (include "alfresco-search-enterprise.fullname" $atsCtx) }}
             - name: ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL
               valueFrom:
                 configMapKeyRef:
                   name: {{ $ats_cm }}
-                  key: {{ .Values.ats.existingConfigMap.keys.transform_url }}
-            {{- range $key, $val := deepCopy .Values.liveIndexing.environment | mustMerge .Values.liveIndexing.mediation.environment }}
+                  key: {{ $.Values.ats.existingConfigMap.keys.transform_url }}
+            {{- range $key, $val := deepCopy $.Values.liveIndexing.environment | mustMerge .environment }}
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
@@ -55,7 +54,7 @@ spec:
             httpGet:
               path: /actuator/health
               port: http
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+          resources: {{- toYaml $.Values.resources | nindent 12 }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -67,4 +66,5 @@ spec:
       {{- with $.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}

--- a/charts/alfresco-search-enterprise/templates/statefulset-mediation.yaml
+++ b/charts/alfresco-search-enterprise/templates/statefulset-mediation.yaml
@@ -55,6 +55,14 @@ spec:
               path: /actuator/health
               port: http
           resources: {{- toYaml $.Values.resources | nindent 12 }}
+          {{- with coalesce .extraVolumeMounts $.Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with coalesce .extraVolumes $.Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/alfresco-search-enterprise/tests/envs_test.yaml
+++ b/charts/alfresco-search-enterprise/tests/envs_test.yaml
@@ -1,0 +1,94 @@
+---
+suite: test environment variables merging
+templates:
+  - deployment.yaml
+  - reindexing-job.yaml
+  - statefulset-mediation.yaml
+tests:
+  - it: should render envs everywhere
+    values: &testvalues
+      - values/embedded-charts-values.yaml
+    set:
+      reindexing:
+        enabled: true
+        environment:
+          env1: VALUE1
+      liveIndexing:
+        environment:
+          env1: VALUE1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env1
+            value: VALUE1
+  - it: should render envs in reindexing job only
+    values: *testvalues
+    set:
+      reindexing:
+        enabled: true
+        environment:
+          env1: VALUE1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env1
+            value: VALUE1
+        documentSelector:
+          path: kind
+          value: Job
+          skipEmptyTemplates: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env1
+            value: VALUE1
+        documentSelector:
+          path: kind
+          value: Deployment
+          skipEmptyTemplates: true
+          matchMany: true
+  - it: should prefer more specific values in deployments
+    values: *testvalues
+    set:
+      liveIndexing:
+        environment:
+          env1: VALUE1
+        metadata:
+          environment:
+            env1: VALUE2
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env1
+            value: VALUE2
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-metadata
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env1
+            value: VALUE1
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-content
+  - it: should prefer more specific values in statefulset
+    values: *testvalues
+    set:
+      liveIndexing:
+        environment:
+          env1: VALUE1
+        mediation:
+          environment:
+            env1: VALUE2
+    template: statefulset-mediation.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env1
+            value: VALUE2

--- a/charts/alfresco-search-enterprise/tests/extras_test.yaml
+++ b/charts/alfresco-search-enterprise/tests/extras_test.yaml
@@ -1,0 +1,123 @@
+---
+suite: test generic Extra resources
+templates:
+  - deployment.yaml
+  - reindexing-job.yaml
+  - statefulset-mediation.yaml
+tests:
+  - it: should have no extra resource by default
+    values: &testvalues
+      - values/embedded-charts-values.yaml
+    set:
+      reindexing:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+      - notExists:
+          path: spec.template.spec.volumes
+  - it: should have global extra resources
+    values: *testvalues
+    set:
+      extraVolumes:
+        - name: extra-volume
+          secret:
+            secretName: extra-secret
+      extraVolumeMounts:
+        - name: extra-volume
+          mountPath: /extra
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-volume
+            mountPath: /extra
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-volume
+            secret:
+              secretName: extra-secret
+  - it: should have a mix of global & local extra resources in deployments
+    values: *testvalues
+    set:
+      extraVolumes:
+        - name: extra-volume
+          secret:
+            secretName: extra-secret
+      liveIndexing:
+        metadata:
+          extraVolumeMounts:
+            - name: extra-volume
+              mountPath: /extra
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-volume
+            mountPath: /extra
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-metadata
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-content
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-volume
+            secret:
+              secretName: extra-secret
+  - it: should have a mix of global & local extra resources in sts
+    values: *testvalues
+    set:
+      extraVolumes:
+        - name: extra-volume
+          secret:
+            secretName: extra-secret
+      liveIndexing:
+        mediation:
+          extraVolumeMounts:
+            - name: extra-volume
+              mountPath: /extra
+    template: statefulset-mediation.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-volume
+            mountPath: /extra
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-volume
+            secret:
+              secretName: extra-secret
+  - it: should have a mix of global & local extra resources in reindexing job
+    values: *testvalues
+    set:
+      extraVolumes:
+        - name: extra-volume
+          secret:
+            secretName: extra-secret
+      reindexing:
+        enabled: true
+        extraVolumeMounts:
+          - name: extra-volume
+            mountPath: /extra
+    template: reindexing-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-volume
+            mountPath: /extra
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-volume
+            secret:
+              secretName: extra-secret

--- a/docs/guides/alfresco-search-enterprise.md
+++ b/docs/guides/alfresco-search-enterprise.md
@@ -1,0 +1,5 @@
+---
+title: Alfresco Search Enterprise
+parent: Guides
+has_children: true
+---


### PR DESCRIPTION
Ref: OPSEXP-3225

Provides comprehensive instructions on how to mount a custom keystore (addresses #463 )