### PR TITLE
OPSEXP-3486 Bump probes and remove jvm heap size setting for elastic chart

### DIFF
--- a/charts/elastic/Chart.yaml
+++ b/charts/elastic/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   sure to deploy your own enterprise grade Elasticsearch instance and configure
   Alfresco charts to point to it.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "8.17.3"
 dependencies:
   - name: alfresco-common

--- a/charts/elastic/README.md
+++ b/charts/elastic/README.md
@@ -39,7 +39,7 @@ Alfresco charts to point to it.
 | elasticsearch.livenessProbe.exec.command[0] | string | `"sh"` |  |
 | elasticsearch.livenessProbe.exec.command[1] | string | `"-c"` |  |
 | elasticsearch.livenessProbe.exec.command[2] | string | `"curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"` |  |
-| elasticsearch.livenessProbe.initialDelaySeconds | int | `100` |  |
+| elasticsearch.livenessProbe.initialDelaySeconds | int | `60` |  |
 | elasticsearch.livenessProbe.periodSeconds | int | `20` |  |
 | elasticsearch.livenessProbe.timeoutSeconds | int | `5` |  |
 | elasticsearch.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
@@ -52,7 +52,7 @@ Alfresco charts to point to it.
 | elasticsearch.readinessProbe.exec.command[0] | string | `"sh"` |  |
 | elasticsearch.readinessProbe.exec.command[1] | string | `"-c"` |  |
 | elasticsearch.readinessProbe.exec.command[2] | string | `"curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"` |  |
-| elasticsearch.readinessProbe.initialDelaySeconds | int | `100` |  |
+| elasticsearch.readinessProbe.initialDelaySeconds | int | `60` |  |
 | elasticsearch.readinessProbe.periodSeconds | int | `20` |  |
 | elasticsearch.readinessProbe.timeoutSeconds | int | `5` |  |
 | elasticsearch.resources.limits.cpu | int | `1` |  |

--- a/charts/elastic/README.md
+++ b/charts/elastic/README.md
@@ -1,6 +1,6 @@
 # elastic
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.17.3](https://img.shields.io/badge/AppVersion-8.17.3-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.17.3](https://img.shields.io/badge/AppVersion-8.17.3-informational?style=flat-square)
 
 WARNING: This chart is meant to ease initial deployment for TESTING purposes.
 DO NOT use this chart in any staging, or production environment. It has very
@@ -39,7 +39,7 @@ Alfresco charts to point to it.
 | elasticsearch.livenessProbe.exec.command[0] | string | `"sh"` |  |
 | elasticsearch.livenessProbe.exec.command[1] | string | `"-c"` |  |
 | elasticsearch.livenessProbe.exec.command[2] | string | `"curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"` |  |
-| elasticsearch.livenessProbe.initialDelaySeconds | int | `30` |  |
+| elasticsearch.livenessProbe.initialDelaySeconds | int | `100` |  |
 | elasticsearch.livenessProbe.periodSeconds | int | `20` |  |
 | elasticsearch.livenessProbe.timeoutSeconds | int | `5` |  |
 | elasticsearch.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
@@ -52,7 +52,7 @@ Alfresco charts to point to it.
 | elasticsearch.readinessProbe.exec.command[0] | string | `"sh"` |  |
 | elasticsearch.readinessProbe.exec.command[1] | string | `"-c"` |  |
 | elasticsearch.readinessProbe.exec.command[2] | string | `"curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"` |  |
-| elasticsearch.readinessProbe.initialDelaySeconds | int | `30` |  |
+| elasticsearch.readinessProbe.initialDelaySeconds | int | `100` |  |
 | elasticsearch.readinessProbe.periodSeconds | int | `20` |  |
 | elasticsearch.readinessProbe.timeoutSeconds | int | `5` |  |
 | elasticsearch.resources.limits.cpu | int | `1` |  |

--- a/charts/elastic/templates/elasticsearch-statefulset.yaml
+++ b/charts/elastic/templates/elasticsearch-statefulset.yaml
@@ -36,8 +36,6 @@ spec:
               value: "false"
             - name: discovery.type
               value: "single-node"
-            - name: ES_JAVA_OPTS
-              value: "-Xms256m -Xmx512m"
           {{- if .Values.elasticsearch.credentials.enabled }}
             - name: ELASTIC_USERNAME
               valueFrom:

--- a/charts/elastic/values.yaml
+++ b/charts/elastic/values.yaml
@@ -52,7 +52,7 @@ elasticsearch:
         - sh
         - -c
         - "curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"
-    initialDelaySeconds: 30
+    initialDelaySeconds: 100
     periodSeconds: 20
     timeoutSeconds: 5
   readinessProbe:
@@ -61,7 +61,7 @@ elasticsearch:
         - sh
         - -c
         - "curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"
-    initialDelaySeconds: 30
+    initialDelaySeconds: 100
     periodSeconds: 20
     timeoutSeconds: 5
 kibana:

--- a/charts/elastic/values.yaml
+++ b/charts/elastic/values.yaml
@@ -52,7 +52,7 @@ elasticsearch:
         - sh
         - -c
         - "curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"
-    initialDelaySeconds: 100
+    initialDelaySeconds: 60
     periodSeconds: 20
     timeoutSeconds: 5
   readinessProbe:
@@ -61,7 +61,7 @@ elasticsearch:
         - sh
         - -c
         - "curl -s -X GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"
-    initialDelaySeconds: 100
+    initialDelaySeconds: 60
     periodSeconds: 20
     timeoutSeconds: 5
 kibana:


### PR DESCRIPTION
ref: OPSEXP-3486

Starting from 7.11 elastic manages jvm heap size automatically based on limits on resources: https://www.elastic.co/guide/en/cloud-on-k8s/1.9/k8s-jvm-heap-size.html
https://www.elastic.co/docs/reference/elasticsearch/jvm-settings#set-jvm-heap-size