### PR TITLE
OPSEXP-4003 Add namespace in hazelcast share cluster role resource names

### DIFF
--- a/charts/alfresco-share/Chart.yaml
+++ b/charts/alfresco-share/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-share
 description: Alfresco Share Helm chart for Kubernetes
 type: application
-version: 2.1.0
+version: 2.1.1
 appVersion: 26.1.0
 dependencies:
   - repository: https://alfresco.github.io/alfresco-helm-charts

--- a/charts/alfresco-share/README.md
+++ b/charts/alfresco-share/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-share
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
 
 Alfresco Share Helm chart for Kubernetes
 

--- a/charts/alfresco-share/templates/_helpers-name.tpl
+++ b/charts/alfresco-share/templates/_helpers-name.tpl
@@ -9,11 +9,11 @@
 {{- end }}
 
 {{- define "alfresco-share.cluster-role-hz.name" -}}
-{{- $scope := (dict "Values" (dict "nameOverride" "share-hazelcast-cluster-role" ) "Chart" .Chart "Release" .Release) }}
+{{- $scope := (dict "Values" (dict "nameOverride" (printf "%s-share-hazelcast-cluster-role" .Release.Namespace) ) "Chart" .Chart "Release" .Release) }}
 {{- include "alfresco-share.fullname" $scope }}
 {{- end }}
 
 {{- define "alfresco-share.cluster-role-binding-hz.name" -}}
-{{- $scope := (dict "Values" (dict "nameOverride" "share-hazelcast-cluster-role-binding" ) "Chart" .Chart "Release" .Release) }}
+{{- $scope := (dict "Values" (dict "nameOverride" (printf "%s-share-hazelcast-cluster-role-binding" .Release.Namespace) ) "Chart" .Chart "Release" .Release) }}
 {{- include "alfresco-share.fullname" $scope }}
 {{- end }}

--- a/charts/alfresco-share/tests/rbac_test.yaml
+++ b/charts/alfresco-share/tests/rbac_test.yaml
@@ -16,3 +16,36 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should use release name in ClusterRole name
+    set:
+      replicaCount: 2
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-NAMESPACE-share-hazelcast-cluster-role
+
+  - it: should use release name in ClusterRoleBinding name
+    set:
+      replicaCount: 2
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-NAMESPACE-share-hazelcast-cluster-role-binding
+
+  - it: should use different names when release name changes
+    release:
+      name: my-release
+    set:
+      replicaCount: 2
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: my-release-NAMESPACE-share-hazelcast-cluster-role
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: my-release-NAMESPACE-share-hazelcast-cluster-role-binding

--- a/charts/alfresco-share/tests/rbac_test.yaml
+++ b/charts/alfresco-share/tests/rbac_test.yaml
@@ -17,7 +17,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should use release name in ClusterRole name
+  - it: should use release name and namespace in ClusterRole name
     set:
       replicaCount: 2
     asserts:
@@ -26,7 +26,7 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-NAMESPACE-share-hazelcast-cluster-role
 
-  - it: should use release name in ClusterRoleBinding name
+  - it: should use release name and namespace in ClusterRoleBinding name
     set:
       replicaCount: 2
     asserts:


### PR DESCRIPTION
Fix #578 OPSEXP-4003

This pull request updates the `alfresco-share` Helm chart to improve the naming of Hazelcast RBAC resources, ensuring they are unique per release and namespace. It also adds tests to verify this behavior and bumps the chart version to reflect the change.