### PR TITLE
OPSEXP-4003 Add namespace to alfresco-sync cluster role resource names

### DIFF
--- a/charts/alfresco-sync-service/Chart.yaml
+++ b/charts/alfresco-sync-service/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 description: Alfresco Sync Service
-version: 7.10.0
+version: 7.10.1
 appVersion: 5.3.1
 keywords:
   - syncservice

--- a/charts/alfresco-sync-service/README.md
+++ b/charts/alfresco-sync-service/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-sync-service
 
-![Version: 7.10.0](https://img.shields.io/badge/Version-7.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.3.1](https://img.shields.io/badge/AppVersion-5.3.1-informational?style=flat-square)
+![Version: 7.10.1](https://img.shields.io/badge/Version-7.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.3.1](https://img.shields.io/badge/AppVersion-5.3.1-informational?style=flat-square)
 
 Alfresco Sync Service
 

--- a/charts/alfresco-sync-service/templates/_helpers-name.tpl
+++ b/charts/alfresco-sync-service/templates/_helpers-name.tpl
@@ -45,11 +45,11 @@ Usage "alfresco-sync-service.repository" $
 {{- end }}
 
 {{- define "alfresco-sync-service.cluster-role-hz.name" -}}
-{{- $scope := (dict "Values" (dict "nameOverride" "sync-hazelcast-cluster-role" ) "Chart" .Chart "Release" .Release) }}
+{{- $scope := (dict "Values" (dict "nameOverride" (printf "%s-sync-hazelcast-cluster-role" .Release.Namespace) ) "Chart" .Chart "Release" .Release) }}
 {{- include "alfresco-sync-service.fullname" $scope }}
 {{- end }}
 
 {{- define "alfresco-sync-service.cluster-role-binding-hz.name" -}}
-{{- $scope := (dict "Values" (dict "nameOverride" "sync-hazelcast-cluster-role-binding" ) "Chart" .Chart "Release" .Release) }}
+{{- $scope := (dict "Values" (dict "nameOverride" (printf "%s-sync-hazelcast-cluster-role-binding" .Release.Namespace) ) "Chart" .Chart "Release" .Release) }}
 {{- include "alfresco-sync-service.fullname" $scope }}
 {{- end }}

--- a/charts/alfresco-sync-service/tests/rbac_test.yaml
+++ b/charts/alfresco-sync-service/tests/rbac_test.yaml
@@ -16,3 +16,36 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should use release name in ClusterRole name
+    set:
+      replicaCount: 2
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-NAMESPACE-sync-hazelcast-cluster-role
+
+  - it: should use release name in ClusterRoleBinding name
+    set:
+      replicaCount: 2
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-NAMESPACE-sync-hazelcast-cluster-role-binding
+
+  - it: should use different names when release name changes
+    release:
+      name: my-release
+    set:
+      replicaCount: 2
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: my-release-NAMESPACE-sync-hazelcast-cluster-role
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: my-release-NAMESPACE-sync-hazelcast-cluster-role-binding


### PR DESCRIPTION
Fix #578 OPSEXP-4003

This pull request updates the Alfresco Sync Service Helm chart to version 7.10.1 and introduces improvements to the naming of Kubernetes ClusterRole and ClusterRoleBinding resources, ensuring they are unique per release namespace. It also adds tests to verify the new naming logic.