### PR TITLE
feat: add support for service.annotations in repository and share charts

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: 26.1.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,11 +5,22 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 
 Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for an example of how to leverage this chart from an umbrella chart.
+
+## Service annotations
+
+Use `service.annotations` to add annotations to the repository Kubernetes Service. For example, to enable Traefik sticky sessions:
+
+```yaml
+service:
+  annotations:
+    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoRepo
+```
 
 ## Requirements
 
@@ -149,6 +160,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | resources.requests.cpu | string | `"2"` |  |
 | resources.requests.memory | string | `"2Gi"` |  |
 | securityContext | object | `{}` |  |
+| service.annotations | object | `{}` | Annotations to add to the repository service. |
 | service.name | string | `"repository"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/alfresco-repository/README.md.gotmpl
+++ b/charts/alfresco-repository/README.md.gotmpl
@@ -12,6 +12,17 @@ parent: Charts Reference
 
 Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for an example of how to leverage this chart from an umbrella chart.
 
+## Service annotations
+
+Use `service.annotations` to add annotations to the repository Kubernetes Service. For example, to enable Traefik sticky sessions:
+
+```yaml
+service:
+  annotations:
+    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoRepo
+```
+
 {{ template "chart.homepageLine" . }}
 
 {{ template "chart.maintainersSection" . }}

--- a/charts/alfresco-repository/templates/service-repository.yaml
+++ b/charts/alfresco-repository/templates/service-repository.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "alfresco-repository.fullname" . }}
   labels:
     {{- include "alfresco-repository.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/alfresco-repository/tests/service_test.yaml
+++ b/charts/alfresco-repository/tests/service_test.yaml
@@ -1,0 +1,22 @@
+---
+suite: test repository service
+templates:
+  - service-repository.yaml
+tests:
+  - it: should not render annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: should render service annotations
+    set:
+      service:
+        annotations:
+          traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+          traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoRepo
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+            traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoRepo

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -235,6 +235,8 @@ service:
   name: repository
   type: ClusterIP
   port: 80
+  # -- Annotations to add to the repository service.
+  annotations: {}
 ingress:
   # -- Toggle ingress
   enabled: true

--- a/charts/alfresco-share/Chart.yaml
+++ b/charts/alfresco-share/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-share
 description: Alfresco Share Helm chart for Kubernetes
 type: application
-version: 2.1.1
+version: 2.2.0
 appVersion: 26.1.0
 dependencies:
   - repository: https://alfresco.github.io/alfresco-helm-charts

--- a/charts/alfresco-share/README.md
+++ b/charts/alfresco-share/README.md
@@ -5,11 +5,22 @@ parent: Charts Reference
 
 # alfresco-share
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
 
 Alfresco Share Helm chart for Kubernetes
 
 Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for an example of how to leverage this chart from an umbrella chart.
+
+## Service annotations
+
+Use `service.annotations` to add annotations to the Share Kubernetes Service. For example, to enable Traefik sticky sessions:
+
+```yaml
+service:
+  annotations:
+    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoShare
+```
 
 ## Requirements
 
@@ -84,6 +95,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | securityContext.capabilities.drop[0] | string | `"NET_RAW"` |  |
 | securityContext.capabilities.drop[1] | string | `"ALL"` |  |
 | securityContext.runAsNonRoot | bool | `false` |  |
+| service.annotations | object | `{}` | Annotations to add to the Share service. |
 | service.name | string | `"share"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/alfresco-share/README.md.gotmpl
+++ b/charts/alfresco-share/README.md.gotmpl
@@ -12,6 +12,17 @@ parent: Charts Reference
 
 Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for an example of how to leverage this chart from an umbrella chart.
 
+## Service annotations
+
+Use `service.annotations` to add annotations to the Share Kubernetes Service. For example, to enable Traefik sticky sessions:
+
+```yaml
+service:
+  annotations:
+    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoShare
+```
+
 {{ template "chart.homepageLine" . }}
 
 {{ template "chart.maintainersSection" . }}

--- a/charts/alfresco-share/templates/service.yaml
+++ b/charts/alfresco-share/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ template "alfresco-share.fullname" . }}
   labels:
     {{- include "alfresco-share.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/alfresco-share/tests/service_test.yaml
+++ b/charts/alfresco-share/tests/service_test.yaml
@@ -8,8 +8,23 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-alfresco-share
+      - isNull:
+          path: metadata.annotations
       - equal:
           path: spec.selector
           value:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: alfresco-share
+
+  - it: should render service annotations
+    set:
+      service:
+        annotations:
+          traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+          traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoShare
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+            traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoShare

--- a/charts/alfresco-share/values.yaml
+++ b/charts/alfresco-share/values.yaml
@@ -62,6 +62,8 @@ service:
   name: share
   type: ClusterIP
   port: 80
+  # -- Annotations to add to the Share service.
+  annotations: {}
 ingress:
   enabled: true
   className: ""


### PR DESCRIPTION
## Summary

Add support for configurable Kubernetes Service annotations in the `alfresco-repository` and `alfresco-share` charts.

This allows users to configure service-level features, such as Traefik sticky sessions, declaratively through `values.yaml` instead of relying on post-deploy `kubectl patch` commands.

## Changes

- Added `service.annotations` to `alfresco-repository`
- Added `service.annotations` to `alfresco-share`
- Render annotations on the primary Service metadata when configured
- Keep default behavior unchanged with `service.annotations: {}`
- Added documentation examples for Traefik sticky sessions
- Added Helm unit test coverage for service annotations
- Bumped affected chart versions

## Example

```yaml
service:
  annotations:
    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
    traefik.ingress.kubernetes.io/service.sticky.cookie.name: alfrescoShare

## Testings done

- `ct lint --config ct.yaml --charts charts/alfresco-repository`
- `ct lint --config ct.yaml --charts charts/alfresco-share`
- `helm unittest --color charts/alfresco-repository`
- `helm unittest --color charts/alfresco-share`