### PR TITLE
OPSEXP-4042: move Elasticsearch index limit settings to createIndexTemplate init container

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.6.0-alpha.0
+version: 1.6.0-alpha.1
 appVersion: 26.1.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.6.0-alpha.0](https://img.shields.io/badge/Version-1.6.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
+![Version: 1.6.0-alpha.1](https://img.shields.io/badge/Version-1.6.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 
@@ -138,11 +138,13 @@ service:
 | initContainers.createIndexTemplate.image.repository | string | `"curlimages/curl"` |  |
 | initContainers.createIndexTemplate.image.tag | string | `"8.11.0"` |  |
 | initContainers.createIndexTemplate.indexName | string | `"alfresco"` | Index name to apply the template to |
+| initContainers.createIndexTemplate.maxResultWindow | int | `10000` | Maximum number of results that can be returned by a single search request. |
 | initContainers.createIndexTemplate.numberOfReplicas | int | `0` | Number of replicas for the index |
 | initContainers.createIndexTemplate.numberOfShards | int | `1` | Number of shards for the index |
 | initContainers.createIndexTemplate.resources.limits.cpu | string | `"250m"` |  |
 | initContainers.createIndexTemplate.resources.limits.memory | string | `"20Mi"` |  |
 | initContainers.createIndexTemplate.templateName | string | `"alfresco-template"` | Template name for the index template |
+| initContainers.createIndexTemplate.totalFieldsLimit | int | `7500` | Maximum number of fields that can be created in the index mapping. |
 | initContainers.waitDbReady.image.pullPolicy | string | `"IfNotPresent"` |  |
 | initContainers.waitDbReady.image.repository | string | `"busybox"` |  |
 | initContainers.waitDbReady.image.tag | string | `"1.37"` |  |

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -79,8 +79,6 @@ service:
 | configuration.search.elasticsearchProperties."archive.indexName" | string | `"alfresco-archive"` | Name of the archive search index to use. |
 | configuration.search.elasticsearchProperties."index.custom.analyzer.config.files" | string | `""` | Custom language analyzer configuration files. Multiple files can be specified as a comma-separated list (e.g. `file:/path/to/file.txt,file:/path/to/file2.txt`). |
 | configuration.search.elasticsearchProperties."index.locale" | string | `"en"` | Locale used for the Elasticsearch language analyzer. |
-| configuration.search.elasticsearchProperties."index.mapping.total_fields.limit" | int | `7500` | Maximum number of fields allowed in the search index mapping. |
-| configuration.search.elasticsearchProperties."index.max_result_window" | int | `10000` | Maximum number of results that can be returned by a single query. |
 | configuration.search.elasticsearchProperties."ssl.host.name.verification" | bool | `true` | When using TLS (`https` or `mtls`), whether to verify the server certificate hostname matches. |
 | configuration.search.elasticsearchProperties.createIndexIfNotExists | bool | `true` | Automatically create the search index if it does not exist at repository startup. Enabled by default for convenience but it is recommended to disable it in production and create the index with the right shards/replicas settings beforehand. See also the `indexInit` feature in the `alfresco-search-enterprise` chart. |
 | configuration.search.elasticsearchProperties.indexName | string | `"alfresco"` | Name of the search index to use. |

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -79,6 +79,8 @@ service:
 | configuration.search.elasticsearchProperties."archive.indexName" | string | `"alfresco-archive"` | Name of the archive search index to use. |
 | configuration.search.elasticsearchProperties."index.custom.analyzer.config.files" | string | `""` | Custom language analyzer configuration files. Multiple files can be specified as a comma-separated list (e.g. `file:/path/to/file.txt,file:/path/to/file2.txt`). |
 | configuration.search.elasticsearchProperties."index.locale" | string | `"en"` | Locale used for the Elasticsearch language analyzer. |
+| configuration.search.elasticsearchProperties."index.mapping.total_fields.limit" | int | `7500` | Maximum number of fields allowed in the search index mapping. |
+| configuration.search.elasticsearchProperties."index.max_result_window" | int | `10000` | Maximum number of results that can be returned by a single query. |
 | configuration.search.elasticsearchProperties."ssl.host.name.verification" | bool | `true` | When using TLS (`https` or `mtls`), whether to verify the server certificate hostname matches. |
 | configuration.search.elasticsearchProperties.createIndexIfNotExists | bool | `true` | Automatically create the search index if it does not exist at repository startup. Enabled by default for convenience but it is recommended to disable it in production and create the index with the right shards/replicas settings beforehand. See also the `indexInit` feature in the `alfresco-search-enterprise` chart. |
 | configuration.search.elasticsearchProperties.indexName | string | `"alfresco"` | Name of the search index to use. |
@@ -136,13 +138,11 @@ service:
 | initContainers.createIndexTemplate.image.repository | string | `"curlimages/curl"` |  |
 | initContainers.createIndexTemplate.image.tag | string | `"8.11.0"` |  |
 | initContainers.createIndexTemplate.indexName | string | `"alfresco"` | Index name to apply the template to |
-| initContainers.createIndexTemplate.maxResultWindow | int | `10000` | Maximum number of results that can be returned by a single search request. |
 | initContainers.createIndexTemplate.numberOfReplicas | int | `0` | Number of replicas for the index |
 | initContainers.createIndexTemplate.numberOfShards | int | `1` | Number of shards for the index |
 | initContainers.createIndexTemplate.resources.limits.cpu | string | `"250m"` |  |
 | initContainers.createIndexTemplate.resources.limits.memory | string | `"20Mi"` |  |
 | initContainers.createIndexTemplate.templateName | string | `"alfresco-template"` | Template name for the index template |
-| initContainers.createIndexTemplate.totalFieldsLimit | int | `7500` | Maximum number of fields that can be created in the index mapping. |
 | initContainers.waitDbReady.image.pullPolicy | string | `"IfNotPresent"` |  |
 | initContainers.waitDbReady.image.repository | string | `"busybox"` |  |
 | initContainers.waitDbReady.image.tag | string | `"1.37"` |  |

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -83,22 +83,25 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              {{- $indexName := .Values.initContainers.createIndexTemplate.indexName }}
+              {{- $maxResultWindow := .Values.initContainers.createIndexTemplate.maxResultWindow }}
+              {{- $totalFieldsLimit := .Values.initContainers.createIndexTemplate.totalFieldsLimit }}
               ES_URL="${SPRING_ELASTICSEARCH_REST_URIS%%,*}"
               until curl -sf -XPUT \
                 -H "Content-Type: application/json" \
                 -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
                 "${ES_URL}/_index_template/{{ .Release.Name }}-{{ .Values.initContainers.createIndexTemplate.templateName }}" \
                 -d '{
-                  "index_patterns": ["{{ .Values.initContainers.createIndexTemplate.indexName }}"],
+                  "index_patterns": ["{{ $indexName }}"],
                   "template": {
                     "settings": {
                       "number_of_shards": {{ .Values.initContainers.createIndexTemplate.numberOfShards }},
                       "number_of_replicas": {{ .Values.initContainers.createIndexTemplate.numberOfReplicas }},
                       "index": {
-                        "max_result_window": {{ index .Values.configuration.search.elasticsearchProperties "index.max_result_window" | default 10000 }},
+                        "max_result_window": {{ $maxResultWindow }},
                         "mapping": {
                           "total_fields": {
-                            "limit": {{ index .Values.configuration.search.elasticsearchProperties "index.mapping.total_fields.limit" | default 7500 }}
+                            "limit": {{ $totalFieldsLimit }}
                           }
                         }
                       }

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -83,20 +83,21 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              {{- $indexName := .Values.initContainers.createIndexTemplate.indexName }}
-              {{- $maxResultWindow := .Values.initContainers.createIndexTemplate.maxResultWindow }}
-              {{- $totalFieldsLimit := .Values.initContainers.createIndexTemplate.totalFieldsLimit }}
+              {{- with .Values.initContainers.createIndexTemplate }}
+              {{- $indexName := .indexName }}
+              {{- $maxResultWindow := .maxResultWindow }}
+              {{- $totalFieldsLimit := .totalFieldsLimit }}
               ES_URL="${SPRING_ELASTICSEARCH_REST_URIS%%,*}"
               until curl -sf -XPUT \
                 -H "Content-Type: application/json" \
                 -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
-                "${ES_URL}/_index_template/{{ .Release.Name }}-{{ .Values.initContainers.createIndexTemplate.templateName }}" \
+                "${ES_URL}/_index_template/{{ $.Release.Name }}-{{ .templateName }}" \
                 -d '{
                   "index_patterns": ["{{ $indexName }}"],
                   "template": {
                     "settings": {
-                      "number_of_shards": {{ .Values.initContainers.createIndexTemplate.numberOfShards }},
-                      "number_of_replicas": {{ .Values.initContainers.createIndexTemplate.numberOfReplicas }},
+                      "number_of_shards": {{ .numberOfShards }},
+                      "number_of_replicas": {{ .numberOfReplicas }},
                       "index": {
                         "max_result_window": {{ $maxResultWindow }},
                         "mapping": {
@@ -113,6 +114,7 @@ spec:
                 sleep 5
               done
               echo "Index template created successfully"
+              {{- end }}
         {{- end }}
         {{- range .Values.extraInitContainers }}
         {{- list . | toYaml | nindent 8 }}

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -84,25 +84,22 @@ spec:
           args:
             - |
               {{- with .Values.initContainers.createIndexTemplate }}
-              {{- $indexName := .indexName }}
-              {{- $maxResultWindow := .maxResultWindow }}
-              {{- $totalFieldsLimit := .totalFieldsLimit }}
               ES_URL="${SPRING_ELASTICSEARCH_REST_URIS%%,*}"
               until curl -sf -XPUT \
                 -H "Content-Type: application/json" \
                 -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
                 "${ES_URL}/_index_template/{{ $.Release.Name }}-{{ .templateName }}" \
                 -d '{
-                  "index_patterns": ["{{ $indexName }}"],
+                  "index_patterns": ["{{ .indexName }}"],
                   "template": {
                     "settings": {
                       "number_of_shards": {{ .numberOfShards }},
                       "number_of_replicas": {{ .numberOfReplicas }},
                       "index": {
-                        "max_result_window": {{ $maxResultWindow }},
+                        "max_result_window": {{ .maxResultWindow }},
                         "mapping": {
                           "total_fields": {
-                            "limit": {{ $totalFieldsLimit }}
+                            "limit": {{ .totalFieldsLimit }}
                           }
                         }
                       }

--- a/charts/alfresco-repository/tests/create-index-template_test.yaml
+++ b/charts/alfresco-repository/tests/create-index-template_test.yaml
@@ -69,11 +69,6 @@ tests:
           enabled: true
           templateName: custom-tpl
           indexName: custom-index
-      configuration:
-        search:
-          elasticsearchProperties:
-            index.max_result_window: 20000
-            index.mapping.total_fields.limit: 10000
     asserts:
       - equal:
           path: spec.template.spec.initContainers[1].name
@@ -86,10 +81,10 @@ tests:
           pattern: '.*"index_patterns": \["custom-index"\].*'
       - matchRegex:
           path: spec.template.spec.initContainers[1].args[0]
-          pattern: '.*"max_result_window": 20000.*'
+          pattern: '.*"max_result_window": 10000.*'
       - matchRegex:
           path: spec.template.spec.initContainers[1].args[0]
-          pattern: '.*"limit": 10000.*'
+          pattern: '.*"limit": 7500.*'
 
   - it: should use default max_result_window and totalFieldsLimit when not specified
     set:
@@ -117,6 +112,24 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[1].args[0]
           pattern: '.*"limit": 7500.*'
+
+  - it: should use init container overrides for max_result_window and totalFieldsLimit
+    set:
+      initContainers:
+        createIndexTemplate:
+          enabled: true
+          maxResultWindow: 30000
+          totalFieldsLimit: 12000
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: create-index-template
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: '.*"max_result_window": 30000.*'
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: '.*"limit": 12000.*'
 
   - it: should include elasticsearch credentials from search configuration
     set:

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -376,9 +376,9 @@ initContainers:
     templateName: alfresco-template
     # -- Index name to apply the template to
     indexName: alfresco
-    # -- @ignore
+    # @ignore
     maxResultWindow: 10000
-    # -- @ignore
+    # @ignore
     totalFieldsLimit: 7500
     # -- Number of shards for the index
     numberOfShards: 1

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -121,10 +121,6 @@ configuration:
       # specified as a comma-separated list (e.g.
       # `file:/path/to/file.txt,file:/path/to/file2.txt`).
       index.custom.analyzer.config.files: ""
-      # -- Maximum number of fields allowed in the search index mapping.
-      index.mapping.total_fields.limit: 7500
-      # -- Maximum number of results that can be returned by a single query.
-      index.max_result_window: 10000
     existingSecret:
       # -- Optional secret containing search service credentials
       name: null
@@ -377,9 +373,9 @@ initContainers:
     # -- Index name to apply the template to
     indexName: alfresco
     # -- Maximum number of results that can be returned by a single search request.
-    maxResultWindow: 10000
+    maxResultWindow: 10000  # formerly index.max_result_window
     # -- Maximum number of fields that can be created in the index mapping.
-    totalFieldsLimit: 7500
+    totalFieldsLimit: 7500  # formerly index.mapping.total_fields.limit
     # -- Number of shards for the index
     numberOfShards: 1
     # -- Number of replicas for the index

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -121,6 +121,10 @@ configuration:
       # specified as a comma-separated list (e.g.
       # `file:/path/to/file.txt,file:/path/to/file2.txt`).
       index.custom.analyzer.config.files: ""
+      # -- Maximum number of fields allowed in the search index mapping.
+      index.mapping.total_fields.limit: 7500
+      # -- Maximum number of results that can be returned by a single query.
+      index.max_result_window: 10000
     existingSecret:
       # -- Optional secret containing search service credentials
       name: null
@@ -372,10 +376,10 @@ initContainers:
     templateName: alfresco-template
     # -- Index name to apply the template to
     indexName: alfresco
-    # -- Maximum number of results that can be returned by a single search request.
-    maxResultWindow: 10000  # formerly index.max_result_window
-    # -- Maximum number of fields that can be created in the index mapping.
-    totalFieldsLimit: 7500  # formerly index.mapping.total_fields.limit
+    # -- @ignore
+    maxResultWindow: 10000
+    # -- @ignore
+    totalFieldsLimit: 7500
     # -- Number of shards for the index
     numberOfShards: 1
     # -- Number of replicas for the index

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -376,6 +376,10 @@ initContainers:
     templateName: alfresco-template
     # -- Index name to apply the template to
     indexName: alfresco
+    # -- Maximum number of results that can be returned by a single search request.
+    maxResultWindow: 10000
+    # -- Maximum number of fields that can be created in the index mapping.
+    totalFieldsLimit: 7500
     # -- Number of shards for the index
     numberOfShards: 1
     # -- Number of replicas for the index


### PR DESCRIPTION
###OPSEXP-4042
This PR only moves two index template limit settings from configuration.search.elasticsearchProperties to initContainers.createIndexTemplate in the alfresco-repository chart.
Moved settings:

index.mapping.total_fields.limit -> initContainers.createIndexTemplate.totalFieldsLimit
index.max_result_window -> initContainers.createIndexTemplate.maxResultWindow