### PR TITLE
OPSEXP-4042 silence create-index-template curl output and prepare 1.6.0 release

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.6.0-alpha.1
+version: 1.6.0
 appVersion: 26.1.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.6.0-alpha.1](https://img.shields.io/badge/Version-1.6.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 

--- a/charts/alfresco-repository/docs/subsystems.md
+++ b/charts/alfresco-repository/docs/subsystems.md
@@ -43,7 +43,7 @@ Creating the subsystem's secret:
 
 Place all the configuration files in a folder on your local system. Sample
 files can be extracted from the S3 AMP file. For more details on the content of
-the files check out the [Alfresco S3 connector docs](https://docs.alfresco.com/aws-s3/latest/config/#content-store-subsystems).
+the files check out the [Alfresco S3 connector docs](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Connector-for-AWS-S3/7.0/Alfresco-Content-Connector-for-AWS-S3/Configure/Configuring-Content-Connector-for-AWS-S3/Content-store-subsystems).
 
 ```bash
 mkdir s3-config

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
             - |
               {{- with .Values.initContainers.createIndexTemplate }}
               ES_URL="${SPRING_ELASTICSEARCH_REST_URIS%%,*}"
-              until curl -sf -XPUT \
+              until curl -sfS -o /dev/null -XPUT \
                 -H "Content-Type: application/json" \
                 -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
                 "${ES_URL}/_index_template/{{ $.Release.Name }}-{{ .templateName }}" \


### PR DESCRIPTION
OPSEXP-4042

This change improves the create-index-template init container logging and updates the chart version for release.