### PR TITLE
OPSEXP-4042: alfresco-search-enterprise Release 5.0.0

### DIFF
--- a/charts/alfresco-search-enterprise/Chart.yaml
+++ b/charts/alfresco-search-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-enterprise
 description: A Helm chart for deploying Alfresco Elasticsearch connector
 type: application
-version: 5.0.0-alpha.0
+version: 5.0.0
 appVersion: 5.5.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-enterprise
 
-![Version: 5.0.0-alpha.0](https://img.shields.io/badge/Version-5.0.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.5.0](https://img.shields.io/badge/AppVersion-5.5.0-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.5.0](https://img.shields.io/badge/AppVersion-5.5.0-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Elasticsearch connector
 


### PR DESCRIPTION
[OPSEXP-4042](https://hyland.atlassian.net/browse/OPSEXP-4042)

This change removes the optional index initialization Job from the Search Enterprise chart and cleans up all related configuration, documentation, and tests.

Tested this alpha release on https://github.com/Alfresco/acs-deployment/pull/1508
Env creation on https://github.com/Alfresco/terraform-alfresco-pipeline/actions/runs/26571530444

[OPSEXP-4042]: https://hyland.atlassian.net/browse/OPSEXP-4042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ