### PR TITLE
OPSEXP-4102 release alfresco-common 5.1.0 GA

### DIFF
--- a/charts/alfresco-common/Chart.yaml
+++ b/charts/alfresco-common/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   A helper subchart to avoid duplication in alfresco charts and set common
   external dependencies
 type: library
-version: 5.1.0-alpha.0
+version: 5.1.0
 icon: https://avatars0.githubusercontent.com/u/391127?s=200&v=4

--- a/charts/alfresco-common/README.md
+++ b/charts/alfresco-common/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-common
 
-![Version: 5.1.0-alpha.0](https://img.shields.io/badge/Version-5.1.0--alpha.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 A helper subchart to avoid duplication in alfresco charts and set common
 external dependencies


### PR DESCRIPTION
Bump alfresco-common from 5.1.0-alpha.0 to 5.1.0 GA as a prerequisite for the Lithium release.

Fix #612 