### PR TITLE
OPSEXP-4102 auto-trigger chart-version bumps on GitHub releases

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -27,10 +27,13 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-charts
       cancel-in-progress: false
+    env:
+      IS_MAIN_BUMP: ${{ github.event_name == 'release' || github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          ref: ${{ env.IS_MAIN_BUMP == 'true' && 'main' || github.ref }}
 
       - uses: >-
           Alfresco/alfresco-build-tools/.github/actions/get-branch-name@v18.1.0
@@ -63,9 +66,9 @@ jobs:
             🛠 Updatecli pipeline bump
           commit_user_name: ${{ vars.BOT_GITHUB_USERNAME }}
           commit_user_email: ${{ vars.BOT_GITHUB_EMAIL }}
-          branch: ${{ github.ref_name == 'main' && 'updatecli-bump-helm' || github.ref_name }}
-          create_branch: ${{ github.ref_name == 'main' && 'true' || 'false' }}
-          push_options: ${{ github.ref_name == 'main' && '--force' || '' }}
+          branch: ${{ env.IS_MAIN_BUMP == 'true' && 'updatecli-bump-helm' || github.ref_name }}
+          create_branch: ${{ env.IS_MAIN_BUMP }}
+          push_options: ${{ env.IS_MAIN_BUMP == 'true' && '--force' || '' }}
 
   bump-values-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,8 +1,11 @@
 ---
 name: Bump versions
-run-name: Bump ${{ inputs.update-type }} using alfresco-updatecli/${{ inputs.alfresco-updatecli-ref }}
+run-name: >-
+  Bump ${{ inputs.update-type || 'charts' }}${{ github.event_name == 'release' && format(' (triggered by {0})', github.event.release.tag_name) || '' }}
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       update-type:
@@ -20,7 +23,10 @@ jobs:
   bump-charts-dependencies:
     runs-on: ubuntu-latest
     name: Helm charts dependencies
-    if: inputs.update-type == 'charts'
+    if: github.event_name == 'release' || inputs.update-type == 'charts'
+    concurrency:
+      group: ${{ github.workflow }}-charts
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -65,6 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Image tags values dependencies
     if: inputs.update-type == 'values'
+    concurrency:
+      group: ${{ github.workflow }}-values
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Adds a `release: published` trigger to `.github/workflows/updatecli.yaml` so `bump-charts-dependencies` runs automatically whenever `helm/chart-releaser-action` publishes a new chart release — so the `updatecli-bump-helm` is kept automatically up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)