### PR TITLE
OPSEXP-4102 fix workflow trigger on approval

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -30,8 +30,7 @@ jobs:
     if: >-
       (github.event_name == 'pull_request_review' &&
         github.event.review.state == 'approved' &&
-        (github.event.pull_request.user.login == 'dependabot[bot]' ||
-         github.event.pull_request.user.login == 'github-actions[bot]')) ||
+        github.event.pull_request.user.login == 'github-actions[bot]') ||
       github.event_name != 'pull_request_review'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -50,6 +49,8 @@ jobs:
       - name: List changed files
         id: pr-changes
         uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@v18.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,8 +19,7 @@ jobs:
     if: >-
       (github.event_name == 'pull_request_review' &&
         github.event.review.state == 'approved' &&
-        (github.event.pull_request.user.login == 'dependabot[bot]' ||
-         github.event.pull_request.user.login == 'github-actions[bot]')) ||
+        github.event.pull_request.user.login == 'github-actions[bot]') ||
       github.event_name != 'pull_request_review'
     permissions:
       contents: write


### PR DESCRIPTION
* dependabot works fine with standard pull_request
* lint-test with pull_request_review requires the github token in the listing step