### PR TITLE
OPSEXP-4102 fix(release): use BOT_GITHUB_TOKEN so release events trigger updatecli

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -57,5 +57,5 @@ jobs:
           charts_dir: charts
           config: cr.yaml
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: "${{ secrets.BOT_GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"


### PR DESCRIPTION
## Summary

- Swap `CR_TOKEN` in the release workflow from `secrets.GITHUB_TOKEN` to the existing `secrets.BOT_GITHUB_TOKEN` PAT. Releases created with the default `GITHUB_TOKEN` do not fan out to downstream workflows by design, which is why the `on: release` trigger added to `updatecli.yaml` in #615 has never auto-fired. Using the PAT restores that chain naturally — no other changes needed.
- Tighten the job-level `permissions:` for the ambient `GITHUB_TOKEN` from `contents: write` to `contents: read`, since all write operations (chart releases, gh-pages index push) now run under the PAT, which carries its own scopes.

### Side effects to be aware of

- Releases and the gh-pages index commit will now be authored by the bot user instead of `github-actions[bot]`. This matches how updatecli bumps are already attributed.
- `chart-releaser-action` creates one GitHub Release per bumped chart, so each release will fire its own `release` event. Safe because `bump-charts-dependencies` already declares a `concurrency` group with `cancel-in-progress: false` — runs queue serially.
- The release workflow now has a hard dependency on `BOT_GITHUB_TOKEN`. If the PAT expires, releases will fail outright rather than silently succeeding without triggering downstream work. Same expiry already affects `updatecli.yaml`.
