### PR TITLE
OPSEXP-4102 Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,13 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -57,5 +58,5 @@ jobs:
           charts_dir: charts
           config: cr.yaml
         env:
-          CR_TOKEN: "${{ secrets.BOT_GITHUB_TOKEN }}"
+          CR_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           CR_SKIP_EXISTING: "true"


### PR DESCRIPTION
I broke this in https://github.com/Alfresco/alfresco-helm-charts/pull/625 thinking the CR_TOKEN was used also for pushing back to main while it's not 😿 

https://github.com/Alfresco/alfresco-helm-charts/actions/runs/27411964617/job/81015175439#step:7:194