### PR TITLE
OPSEXP-4173 Add alfresco-search-community chart for Elasticsearch batch indexing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ on:
 
 env:
   TEST_ALL_CHARTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci-test-all') && 'true' || 'false' }}
-  HELM_VERSION: v4.2.3
+  HELM_VERSION: v4.1.1
   CHART_TESTING_VERSION: v3.14.0
 jobs:
   list-changed:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ on:
 
 env:
   TEST_ALL_CHARTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci-test-all') && 'true' || 'false' }}
-  HELM_VERSION: v4.1.1
+  HELM_VERSION: v4.2.3
   CHART_TESTING_VERSION: v3.14.0
 jobs:
   list-changed:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,3 +4,6 @@ rules:
   line-length: disable
   indentation: disable
   trailing-spaces: disable
+  empty-lines:
+    max: 2
+    max-end: 1

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,6 +4,3 @@ rules:
   line-length: disable
   indentation: disable
   trailing-spaces: disable
-  empty-lines:
-    max: 2
-    max-end: 1

--- a/charts/alfresco-search-community/.helmignore
+++ b/charts/alfresco-search-community/.helmignore
@@ -1,0 +1,29 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Helm unittest
+tests
+# Chart testing values
+ci
+# helm-docs template
+README.md.gotmpl

--- a/charts/alfresco-search-community/Chart.lock
+++ b/charts/alfresco-search-community/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: alfresco-common
+  repository: https://alfresco.github.io/alfresco-helm-charts/
+  version: 5.1.0
+digest: sha256:dc19a5f99ccbfd9fad0e8f81695b4c54443be4c2dc3665af9854e16a71d5b7fe
+generated: "2026-07-15T16:47:42.394163+02:00"

--- a/charts/alfresco-search-community/Chart.yaml
+++ b/charts/alfresco-search-community/Chart.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v2
+name: alfresco-search-community
+description: A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
+type: application
+version: 0.1.0
+appVersion: 5.7.0-A.5
+dependencies:
+  - name: alfresco-common
+    version: 5.1.0
+    repository: https://alfresco.github.io/alfresco-helm-charts/

--- a/charts/alfresco-search-community/Chart.yaml
+++ b/charts/alfresco-search-community/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-community
 description: A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 type: application
-version: 0.1.0
+version: 0.1.0-alpha.0
 appVersion: 5.7.0-A.5
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-community
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0-A.5](https://img.shields.io/badge/AppVersion-5.7.0--A.5-informational?style=flat-square)
+![Version: 0.1.0-alpha.0](https://img.shields.io/badge/Version-0.1.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0-A.5](https://img.shields.io/badge/AppVersion-5.7.0--A.5-informational?style=flat-square)
 
 A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -1,0 +1,88 @@
+---
+title: alfresco-search-community
+parent: Charts Reference
+---
+
+# alfresco-search-community
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0-A.5](https://img.shields.io/badge/AppVersion-5.7.0--A.5-informational?style=flat-square)
+
+A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
+
+Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for an example of how to leverage this chart from an umbrella chart.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://alfresco.github.io/alfresco-helm-charts/ | alfresco-common | 5.1.0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| additionalLabels | object | `{}` | Additional labels to be added to all resources (deployments, services, pods, etc.) Example:   Product: k8s   Environment: DEV |
+| affinity | object | `{}` |  |
+| db.existingConfigMap.keys.url | string | `"DATABASE_URL"` | Key within the configmap holding the full JDBC url to connect to database service |
+| db.existingConfigMap.name | string | `nil` | Alternatively, provide database connection details via an existing configmap |
+| db.existingSecret.keys.password | string | `"DATABASE_PASSWORD"` | Key within the secret holding the database password |
+| db.existingSecret.keys.username | string | `"DATABASE_USERNAME"` | Key within the secret holding the database username |
+| db.existingSecret.name | string | `nil` | Alternatively, provide database credentials via an existing secret |
+| db.password | string | `nil` | The password required to access the database service |
+| db.url | string | `nil` | Provide the full JDBC url to connect to database service e.g.: `jdbc:postgresql://hostname:5432/database` |
+| db.username | string | `nil` | The username required to access the database service |
+| environment | object | `{}` | Set additional environment variables for the batch indexing container (e.g. `ALFRESCO_REINDEX_*` tunables or `JAVA_OPTS`) |
+| fullnameOverride | string | `""` |  |
+| global.additionalLabels | object | `{}` | Global additional labels that can be set at parent/umbrella chart level These will be merged with chart-level additionalLabels, with chart-level taking precedence |
+| global.alfrescoRegistryPullSecrets | string | `"quay-registry-secret"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"docker.io/alfresco/alfresco-elasticsearch-batch-indexing"` |  |
+| image.tag | string | `"5.7.0-A.5"` |  |
+| imagePullSecrets | list | `[]` |  |
+| index.existingConfigMap.keys.url | string | `"SEARCH_URL"` | Key within the configmap holding the URL of the elasticsearch service |
+| index.existingConfigMap.name | string | `nil` | Alternatively, provide elasticsearch service connection details via an existing configmap |
+| index.existingSecret.keys.password | string | `"SEARCH_PASSWORD"` | Key within the secret that holds the elasticsearch password |
+| index.existingSecret.keys.username | string | `"SEARCH_USERNAME"` | Key within the secret that holds the elasticsearch username |
+| index.existingSecret.name | string | `nil` | Alternatively, provide elasticsearch credentials via an existing secret |
+| index.password | string | `nil` | The password required to access the elasticsearch service, if any |
+| index.url | string | `nil` | The URL where the elasticsearch service is available |
+| index.username | string | `nil` | The username required to access the elasticsearch service, if any |
+| indexName | string | `"alfresco"` | Name of the search index, usually created by the repository |
+| livenessProbe.httpGet.path | string | `"/actuator/health"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.initialDelaySeconds | int | `120` |  |
+| livenessProbe.timeoutSeconds | int | `60` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| readinessProbe.httpGet.path | string | `"/actuator/health"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe.initialDelaySeconds | int | `60` |  |
+| readinessProbe.timeoutSeconds | int | `60` |  |
+| replicaCount | int | `1` | The batch indexing component is a singleton; this value must remain 1 (a second instance conflicts on the shared watermark and self-terminates) |
+| repository.existingConfigMap.keys.url | string | `"REPOSITORY_URL"` | Key within the configmap holding the full url to connect to the alfresco repository |
+| repository.existingConfigMap.name | string | `nil` | Alternatively, provide repository connection details via an existing configmap |
+| repository.url | string | `nil` | URL of the Alfresco repository (ACS) |
+| resources.limits.cpu | string | `"2"` |  |
+| resources.limits.memory | string | `"2048Mi"` |  |
+| resources.requests.cpu | string | `"0.5"` |  |
+| resources.requests.memory | string | `"256Mi"` |  |
+| securityContext | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.port | int | `8080` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| sharedSecret.existingSecret.keys.sharedSecret | string | `"ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET"` | Key within the secret holding the shared secret |
+| sharedSecret.existingSecret.name | string | `nil` | Alternatively, provide the shared secret via an existing secret |
+| sharedSecret.value | string | `nil` | Shared secret used to authenticate content requests against the repository (must match the repository's `solr.sharedSecret`) |
+| tolerations | list | `[]` |  |
+| transform.existingConfigMap.keys.url | string | `"TRANSFORM_URL"` | Key within the configmap holding the URL of the transform config endpoint |
+| transform.existingConfigMap.name | string | `nil` | Alternatively, provide transform config endpoint details via an existing configmap |
+| transform.url | string | `nil` | URL of the alfresco transform config endpoint (e.g. `http://transform-core-aio:8090/transform/config`) |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -35,6 +35,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | fullnameOverride | string | `""` |  |
 | global.additionalLabels | object | `{}` | Global additional labels that can be set at parent/umbrella chart level These will be merged with chart-level additionalLabels, with chart-level taking precedence |
 | global.alfrescoRegistryPullSecrets | string | `"quay-registry-secret"` |  |
+| image.internalPort | int | `8080` | Port the container listens on |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/alfresco/alfresco-elasticsearch-batch-indexing"` |  |
 | image.tag | string | `"5.7.0-A.5"` |  |

--- a/charts/alfresco-search-community/README.md.gotmpl
+++ b/charts/alfresco-search-community/README.md.gotmpl
@@ -1,0 +1,23 @@
+---
+title: {{ template "chart.name" . }}
+parent: Charts Reference
+---
+
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md) for an example of how to leverage this chart from an umbrella chart.
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/alfresco-search-community/ci/default-values.yaml
+++ b/charts/alfresco-search-community/ci/default-values.yaml
@@ -1,0 +1,36 @@
+# avoid too long resource names being truncated and conflicting
+nameOverride: assc
+index:
+  url: http://elasticsearch:9200
+db:
+  url: jdbc:postgresql://postgresql:5432/alfresco
+  username: alfresco
+  password: alfresco
+repository:
+  url: http://alfresco:8080
+transform:
+  url: http://transform-core-aio:8090/transform/config
+sharedSecret:
+  value: secret
+# The batch indexing component needs the Alfresco DB schema (created by the
+# repository) to become healthy, which is not available in chart-testing. Relax
+# the probes to a plain TCP check so the workload is validated as started.
+livenessProbe:
+  httpGet: null
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 120
+  periodSeconds: 30
+readinessProbe:
+  httpGet: null
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    cpu: "1"
+    memory: "1Gi"

--- a/charts/alfresco-search-community/templates/_helpers-config.tpl
+++ b/charts/alfresco-search-community/templates/_helpers-config.tpl
@@ -1,0 +1,32 @@
+{{/*
+
+Render the common plain and referenced env vars for the batch indexing container
+
+Usage: include "alfresco-search-community.config.env" $
+
+*/}}
+{{- define "alfresco-search-community.config.env" -}}
+{{- $repoCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "repository")) "Chart" .Chart "Release" .Release }}
+{{- $repoCm := coalesce .Values.repository.existingConfigMap.name (include "alfresco-search-community.fullname" $repoCtx) }}
+{{- $transformCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "transform")) "Chart" .Chart "Release" .Release }}
+{{- $transformCm := coalesce .Values.transform.existingConfigMap.name (include "alfresco-search-community.fullname" $transformCtx) }}
+{{- $secretCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "shared-secret")) "Chart" .Chart "Release" .Release }}
+{{- $sharedSecret := coalesce .Values.sharedSecret.existingSecret.name (include "alfresco-search-community.fullname" $secretCtx) }}
+- name: ELASTICSEARCH_INDEXNAME
+  value: {{ .Values.indexName | quote }}
+- name: ALFRESCO_ACS_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ $repoCm }}
+      key: {{ .Values.repository.existingConfigMap.keys.url }}
+- name: ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ $transformCm }}
+      key: {{ .Values.transform.existingConfigMap.keys.url }}
+- name: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $sharedSecret }}
+      key: {{ .Values.sharedSecret.existingSecret.keys.sharedSecret }}
+{{- end -}}

--- a/charts/alfresco-search-community/templates/_helpers-db.tpl
+++ b/charts/alfresco-search-community/templates/_helpers-db.tpl
@@ -1,0 +1,26 @@
+{{/*
+
+Usage: include "alfresco-search-community.db.env" $
+
+*/}}
+{{- define "alfresco-search-community.db.env" -}}
+{{- $dbCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "database")) "Chart" .Chart "Release" .Release }}
+{{- $dbFullName := include "alfresco-search-community.fullname" $dbCtx }}
+{{- with .Values.db }}
+- name: SPRING_DATASOURCE_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .existingConfigMap.name | default $dbFullName }}
+      key: {{ .existingConfigMap.keys.url }}
+- name: SPRING_DATASOURCE_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret.name | default $dbFullName }}
+      key: {{ .existingSecret.keys.username }}
+- name: SPRING_DATASOURCE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret.name | default $dbFullName }}
+      key: {{ .existingSecret.keys.password }}
+{{- end }}
+{{- end -}}

--- a/charts/alfresco-search-community/templates/_helpers-elasticsearch.tpl
+++ b/charts/alfresco-search-community/templates/_helpers-elasticsearch.tpl
@@ -1,0 +1,38 @@
+{{/*
+
+Usage: include "alfresco-search-community.es.env" $
+
+*/}}
+{{- define "alfresco-search-community.es.env" -}}
+{{- $esCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "es")) "Chart" .Chart "Release" .Release }}
+{{- with .Values.index }}
+{{- $esCm := coalesce .existingConfigMap.name (include "alfresco-search-community.fullname" $esCtx) }}
+- name: SPRING_ELASTICSEARCH_REST_URIS
+  valueFrom:
+    configMapKeyRef:
+      name: {{ $esCm }}
+      key: {{ .existingConfigMap.keys.url }}
+{{- end }}
+{{- end -}}
+
+{{/*
+
+Usage: include "alfresco-search-community.es.envCredentials" $
+
+*/}}
+{{- define "alfresco-search-community.es.envCredentials" -}}
+{{- $esCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "es")) "Chart" .Chart "Release" .Release }}
+{{- with .Values.index }}
+{{- $esSecret := coalesce .existingSecret.name (include "alfresco-search-community.fullname" $esCtx) }}
+- name: SPRING_ELASTICSEARCH_REST_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $esSecret }}
+      key: {{ .existingSecret.keys.username }}
+- name: SPRING_ELASTICSEARCH_REST_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $esSecret }}
+      key: {{ .existingSecret.keys.password }}
+{{- end }}
+{{- end -}}

--- a/charts/alfresco-search-community/templates/_helpers.tpl
+++ b/charts/alfresco-search-community/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alfresco-search-community.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alfresco-search-community.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alfresco-search-community.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "alfresco-search-community.labels" -}}
+helm.sh/chart: {{ include "alfresco-search-community.chart" . }}
+{{ include "alfresco-search-community.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ .Chart.Name }}
+{{- with mustMerge .Values.additionalLabels .Values.global.additionalLabels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alfresco-search-community.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alfresco-search-community.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "alfresco-search-community.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "alfresco-search-community.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/configmap-database.yaml
+++ b/charts/alfresco-search-community/templates/configmap-database.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.db.existingConfigMap.name }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- $ctx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "database")) "Chart" .Chart "Release" .Release }}
+  name: {{ template "alfresco-search-community.fullname" $ctx }}
+  labels:
+    {{- include "alfresco-search-community.labels" . | nindent 4 }}
+data:
+  {{ .Values.db.existingConfigMap.keys.url }}: {{ required ".db.url is mandatory when not using existingConfigMap" .Values.db.url }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/configmap-es.yaml
+++ b/charts/alfresco-search-community/templates/configmap-es.yaml
@@ -19,6 +19,6 @@ data:
   {{- if not $esHost }}
     {{- fail (printf "%s Invalid URL format missing host. Provided: %s" $reqMsg .url) }}
   {{- end }}
-  SEARCH_URL: {{ printf "%s://%s:%v" $esProtocol $esHost $esPort }}
+  {{ .existingConfigMap.keys.url }}: {{ printf "%s://%s:%v" $esProtocol $esHost $esPort }}
 {{- end }}
 {{- end }}

--- a/charts/alfresco-search-community/templates/configmap-es.yaml
+++ b/charts/alfresco-search-community/templates/configmap-es.yaml
@@ -1,0 +1,24 @@
+{{- with .Values.index }}
+{{- if not .existingConfigMap.name }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- $ctx := dict "Values" (dict "nameOverride" (printf "%s-%s" ($.Values.nameOverride | default $.Chart.Name) "es")) "Chart" $.Chart "Release" $.Release }}
+  name: {{ template "alfresco-search-community.fullname" $ctx }}
+  labels:
+    {{- include "alfresco-search-community.labels" $ | nindent 4 }}
+data:
+  {{- $reqMsg := "Please provide elasticsearch connection details as .index.url values or using an .index.existingConfigMap." }}
+  {{- $assertCondition := required $reqMsg .url }}
+  {{- if not (contains "://" .url) }}
+    {{- fail (printf "%s Invalid URL format - URL must contain '://' scheme separator. Provided: %s" $reqMsg .url) }}
+  {{- end }}
+  {{- $esProtocol := include "alfresco-common.url.scheme" .url }}
+  {{- $esHost := include "alfresco-common.url.host" .url }}
+  {{- $esPort := include "alfresco-common.url.port" .url }}
+  {{- if not $esHost }}
+    {{- fail (printf "%s Invalid URL format missing host. Provided: %s" $reqMsg .url) }}
+  {{- end }}
+  SEARCH_URL: {{ printf "%s://%s:%v" $esProtocol $esHost $esPort }}
+{{- end }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/configmap-repository.yaml
+++ b/charts/alfresco-search-community/templates/configmap-repository.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.repository.existingConfigMap.name }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- $ctx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "repository")) "Chart" .Chart "Release" .Release }}
+  name: {{ template "alfresco-search-community.fullname" $ctx }}
+  labels:
+    {{- include "alfresco-search-community.labels" . | nindent 4 }}
+data:
+  {{ .Values.repository.existingConfigMap.keys.url }}: {{ required ".repository.url is mandatory when not using existingConfigMap" .Values.repository.url }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/configmap-transform.yaml
+++ b/charts/alfresco-search-community/templates/configmap-transform.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.transform.existingConfigMap.name }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- $ctx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "transform")) "Chart" .Chart "Release" .Release }}
+  name: {{ template "alfresco-search-community.fullname" $ctx }}
+  labels:
+    {{- include "alfresco-search-community.labels" . | nindent 4 }}
+data:
+  {{ .Values.transform.existingConfigMap.keys.url }}: {{ required ".transform.url is mandatory when not using existingConfigMap" .Values.transform.url }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/deployment.yaml
+++ b/charts/alfresco-search-community/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           {{- include "alfresco-common.component-security-context" .Values | indent 8 }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.image.internalPort }}
               protocol: TCP
           env:
             {{- include "alfresco-search-community.db.env" $ | nindent 12 }}

--- a/charts/alfresco-search-community/templates/deployment.yaml
+++ b/charts/alfresco-search-community/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alfresco-search-community.fullname" . }}
+  labels:
+    {{- include "alfresco-search-community.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "alfresco-search-community.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "alfresco-search-community.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "alfresco-common.imagePullSecrets" . | indent 6 }}
+      {{- include "alfresco-common.component-pod-security-context" .Values | indent 4 }}
+      serviceAccountName: {{ include "alfresco-search-community.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- include "alfresco-common.component-security-context" .Values | indent 8 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            {{- include "alfresco-search-community.db.env" $ | nindent 12 }}
+            {{- include "alfresco-search-community.es.env" $ | nindent 12 }}
+            {{- include "alfresco-search-community.es.envCredentials" $ | nindent 12 }}
+            {{- include "alfresco-search-community.config.env" $ | nindent 12 }}
+            {{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/alfresco-search-community/templates/secret-database.yaml
+++ b/charts/alfresco-search-community/templates/secret-database.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.db.existingSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- $ctx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "database")) "Chart" .Chart "Release" .Release }}
+  name: {{ template "alfresco-search-community.fullname" $ctx }}
+  labels:
+    {{- include "alfresco-search-community.labels" $ | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.db.existingSecret.keys.username }}: {{ .Values.db.username | default "" | b64enc | quote }}
+  {{ .Values.db.existingSecret.keys.password }}: {{ .Values.db.password | default "" | b64enc | quote }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/secret-es.yaml
+++ b/charts/alfresco-search-community/templates/secret-es.yaml
@@ -1,0 +1,15 @@
+{{- with .Values.index }}
+{{- if not .existingSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- $ctx := dict "Values" (dict "nameOverride" (printf "%s-%s" ($.Values.nameOverride | default $.Chart.Name) "es")) "Chart" $.Chart "Release" $.Release }}
+  name: {{ template "alfresco-search-community.fullname" $ctx }}
+  labels:
+    {{- include "alfresco-search-community.labels" $ | nindent 4 }}
+type: Opaque
+data:
+  SEARCH_USERNAME: {{ .username | default "" | b64enc | quote }}
+  SEARCH_PASSWORD: {{ .password | default "" | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/secret-es.yaml
+++ b/charts/alfresco-search-community/templates/secret-es.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "alfresco-search-community.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  SEARCH_USERNAME: {{ .username | default "" | b64enc | quote }}
-  SEARCH_PASSWORD: {{ .password | default "" | b64enc | quote }}
+  {{ .existingSecret.keys.username }}: {{ .username | default "" | b64enc | quote }}
+  {{ .existingSecret.keys.password }}: {{ .password | default "" | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/charts/alfresco-search-community/templates/secret-shared-secret.yaml
+++ b/charts/alfresco-search-community/templates/secret-shared-secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.sharedSecret.existingSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- $ctx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "shared-secret")) "Chart" .Chart "Release" .Release }}
+  name: {{ template "alfresco-search-community.fullname" $ctx }}
+  labels:
+    {{- include "alfresco-search-community.labels" $ | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.sharedSecret.existingSecret.keys.sharedSecret }}: {{ required ".sharedSecret.value is mandatory when not using existingSecret" .Values.sharedSecret.value | b64enc | quote }}
+{{- end }}

--- a/charts/alfresco-search-community/templates/service.yaml
+++ b/charts/alfresco-search-community/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alfresco-search-community.fullname" . }}
+  labels:
+    {{- include "alfresco-search-community.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "alfresco-search-community.selectorLabels" . | nindent 4 }}

--- a/charts/alfresco-search-community/templates/serviceaccount.yaml
+++ b/charts/alfresco-search-community/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alfresco-search-community.serviceAccountName" . }}
+  labels:
+    {{- include "alfresco-search-community.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/alfresco-search-community/tests/configmaps_test.yaml
+++ b/charts/alfresco-search-community/tests/configmaps_test.yaml
@@ -1,0 +1,58 @@
+suite: test configmaps
+templates:
+  - configmap-es.yaml
+  - configmap-database.yaml
+  - configmap-repository.yaml
+  - configmap-transform.yaml
+values:
+  - values/embedded-charts-values.yaml
+tests:
+  - it: should render normalized elasticsearch url
+    template: configmap-es.yaml
+    asserts:
+      - equal:
+          path: data.SEARCH_URL
+          value: http://elasticsearch:9200
+  - it: should fail when elasticsearch url has no scheme separator
+    template: configmap-es.yaml
+    set:
+      index:
+        url: elasticsearch:9200
+    asserts:
+      - failedTemplate:
+          errorMessage: "Please provide elasticsearch connection details as .index.url values or using an .index.existingConfigMap. Invalid URL format - URL must contain '://' scheme separator. Provided: elasticsearch:9200"
+  - it: should not render elasticsearch configmap when existingConfigMap is set
+    template: configmap-es.yaml
+    set:
+      index:
+        existingConfigMap:
+          name: my-es-cm
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render database url
+    template: configmap-database.yaml
+    asserts:
+      - equal:
+          path: data.DATABASE_URL
+          value: jdbc:postgresql://postgresql:5432/alfresco
+  - it: should fail when database url is missing
+    template: configmap-database.yaml
+    set:
+      db:
+        url: null
+    asserts:
+      - failedTemplate:
+          errorMessage: ".db.url is mandatory when not using existingConfigMap"
+  - it: should render repository url
+    template: configmap-repository.yaml
+    asserts:
+      - equal:
+          path: data.REPOSITORY_URL
+          value: http://alfresco:8080
+  - it: should render transform url
+    template: configmap-transform.yaml
+    asserts:
+      - equal:
+          path: data.TRANSFORM_URL
+          value: http://transform-core-aio:8090/transform/config

--- a/charts/alfresco-search-community/tests/configmaps_test.yaml
+++ b/charts/alfresco-search-community/tests/configmaps_test.yaml
@@ -30,6 +30,17 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should render elasticsearch url under a custom key name
+    template: configmap-es.yaml
+    set:
+      index:
+        existingConfigMap:
+          keys:
+            url: ES_URL
+    asserts:
+      - equal:
+          path: data.ES_URL
+          value: http://elasticsearch:9200
   - it: should render database url
     template: configmap-database.yaml
     asserts:

--- a/charts/alfresco-search-community/tests/deployment_test.yaml
+++ b/charts/alfresco-search-community/tests/deployment_test.yaml
@@ -1,0 +1,274 @@
+suite: test deployment
+templates:
+  - deployment.yaml
+values:
+  - values/embedded-charts-values.yaml
+tests:
+  - it: should have default image pull secret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: quay-registry-secret
+  - it: should have a single replica
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+  - it: should have default container name
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: alfresco-search-community
+  - it: should have custom container image
+    set:
+      image:
+        repository: "custom-repo"
+        tag: "custom-tag"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "custom-repo:custom-tag"
+  - it: should have default container image
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "docker.io/alfresco/alfresco-elasticsearch-batch-indexing:.+"
+  - it: should have default securityContext
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+  - it: should have default ports section
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            containerPort: 8080
+            name: http
+            protocol: TCP
+  - it: should contain default database, elasticsearch, repository and transform envs
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_DATASOURCE_URL
+            valueFrom:
+              configMapKeyRef:
+                key: DATABASE_URL
+                name: RELEASE-NAME-alfresco-search-community-database
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_DATASOURCE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: DATABASE_USERNAME
+                name: RELEASE-NAME-alfresco-search-community-database
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_DATASOURCE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: DATABASE_PASSWORD
+                name: RELEASE-NAME-alfresco-search-community-database
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_URIS
+            valueFrom:
+              configMapKeyRef:
+                key: SEARCH_URL
+                name: RELEASE-NAME-alfresco-search-community-es
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: SEARCH_USERNAME
+                name: RELEASE-NAME-alfresco-search-community-es
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: SEARCH_PASSWORD
+                name: RELEASE-NAME-alfresco-search-community-es
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_INDEXNAME
+            value: alfresco
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_ACS_URL
+            valueFrom:
+              configMapKeyRef:
+                key: REPOSITORY_URL
+                name: RELEASE-NAME-alfresco-search-community-repository
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL
+            valueFrom:
+              configMapKeyRef:
+                key: TRANSFORM_URL
+                name: RELEASE-NAME-alfresco-search-community-transform
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+            valueFrom:
+              secretKeyRef:
+                key: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+                name: RELEASE-NAME-alfresco-search-community-shared-secret
+  - it: should wire envs from external configmaps and secrets
+    set:
+      index:
+        existingConfigMap:
+          name: es-external-config
+          keys:
+            url: SEARCH_URL_EXTERNAL
+        existingSecret:
+          name: es-external-secret
+          keys:
+            username: SEARCH_USERNAME_EXTERNAL
+            password: SEARCH_PASSWORD_EXTERNAL
+      db:
+        existingConfigMap:
+          name: db-external-config
+          keys:
+            url: DATABASE_URL_EXTERNAL
+        existingSecret:
+          name: db-external-secret
+          keys:
+            username: DATABASE_USERNAME_EXTERNAL
+            password: DATABASE_PASSWORD_EXTERNAL
+      repository:
+        existingConfigMap:
+          name: repo-external-config
+          keys:
+            url: REPOSITORY_URL_EXTERNAL
+      transform:
+        existingConfigMap:
+          name: transform-external-config
+          keys:
+            url: TRANSFORM_URL_EXTERNAL
+      sharedSecret:
+        existingSecret:
+          name: shared-secret-external
+          keys:
+            sharedSecret: SHARED_SECRET_EXTERNAL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_DATASOURCE_URL
+            valueFrom:
+              configMapKeyRef:
+                key: DATABASE_URL_EXTERNAL
+                name: db-external-config
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_DATASOURCE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: DATABASE_USERNAME_EXTERNAL
+                name: db-external-secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_URIS
+            valueFrom:
+              configMapKeyRef:
+                key: SEARCH_URL_EXTERNAL
+                name: es-external-config
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: SEARCH_PASSWORD_EXTERNAL
+                name: es-external-secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_ACS_URL
+            valueFrom:
+              configMapKeyRef:
+                key: REPOSITORY_URL_EXTERNAL
+                name: repo-external-config
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL
+            valueFrom:
+              configMapKeyRef:
+                key: TRANSFORM_URL_EXTERNAL
+                name: transform-external-config
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+            valueFrom:
+              secretKeyRef:
+                key: SHARED_SECRET_EXTERNAL
+                name: shared-secret-external
+  - it: should render custom environment variables
+    set:
+      environment:
+        ALFRESCO_REINDEX_CONTINUOUS_POLLINGINTERVAL: 15s
+        JAVA_OPTS: "-Xmx768m"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_REINDEX_CONTINUOUS_POLLINGINTERVAL
+            value: "15s"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: "-Xmx768m"
+  - it: should render custom index name
+    set:
+      indexName: custom-index
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_INDEXNAME
+            value: custom-index
+  - it: should render pods annotations
+    set:
+      podAnnotations:
+        alfresco-helm-charts.github.io/test: annotate-pods
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            alfresco-helm-charts.github.io/test: annotate-pods
+  - it: should render labels
+    chart:
+      version: 1.0.0
+      appVersion: 2.0.0
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/component: alfresco-search-community
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: alfresco-search-community
+            app.kubernetes.io/version: 2.0.0
+            helm.sh/chart: alfresco-search-community-1.0.0

--- a/charts/alfresco-search-community/tests/deployment_test.yaml
+++ b/charts/alfresco-search-community/tests/deployment_test.yaml
@@ -51,6 +51,17 @@ tests:
             containerPort: 8080
             name: http
             protocol: TCP
+  - it: should have custom container port
+    set:
+      image:
+        internalPort: 9090
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            containerPort: 9090
+            name: http
+            protocol: TCP
   - it: should contain default database, elasticsearch, repository and transform envs
     asserts:
       - contains:

--- a/charts/alfresco-search-community/tests/secret-database_test.yaml
+++ b/charts/alfresco-search-community/tests/secret-database_test.yaml
@@ -1,0 +1,22 @@
+suite: test database secret
+templates:
+  - secret-database.yaml
+values:
+  - values/embedded-charts-values.yaml
+tests:
+  - it: should base64 encode provided credentials
+    asserts:
+      - equal:
+          path: data.DATABASE_USERNAME
+          value: YWxmcmVzY28=
+      - equal:
+          path: data.DATABASE_PASSWORD
+          value: YWxmcmVzY28=
+  - it: should not render when existingSecret is set
+    set:
+      db:
+        existingSecret:
+          name: my-db-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/alfresco-search-community/tests/secret-es_test.yaml
+++ b/charts/alfresco-search-community/tests/secret-es_test.yaml
@@ -1,0 +1,34 @@
+suite: test elasticsearch secret
+templates:
+  - secret-es.yaml
+values:
+  - values/embedded-charts-values.yaml
+tests:
+  - it: should base64 encode provided credentials
+    set:
+      index:
+        username: elastic
+        password: s3cr3t
+    asserts:
+      - equal:
+          path: data.SEARCH_USERNAME
+          value: ZWxhc3RpYw==
+      - equal:
+          path: data.SEARCH_PASSWORD
+          value: czNjcjN0
+  - it: should render empty credentials by default
+    asserts:
+      - equal:
+          path: data.SEARCH_USERNAME
+          value: ""
+      - equal:
+          path: data.SEARCH_PASSWORD
+          value: ""
+  - it: should not render when existingSecret is set
+    set:
+      index:
+        existingSecret:
+          name: my-es-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/alfresco-search-community/tests/secret-es_test.yaml
+++ b/charts/alfresco-search-community/tests/secret-es_test.yaml
@@ -32,3 +32,19 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should render credentials under custom key names
+    set:
+      index:
+        username: elastic
+        password: s3cr3t
+        existingSecret:
+          keys:
+            username: ES_USER
+            password: ES_PASSWORD
+    asserts:
+      - equal:
+          path: data.ES_USER
+          value: ZWxhc3RpYw==
+      - equal:
+          path: data.ES_PASSWORD
+          value: czNjcjN0

--- a/charts/alfresco-search-community/tests/secret-shared-secret_test.yaml
+++ b/charts/alfresco-search-community/tests/secret-shared-secret_test.yaml
@@ -1,0 +1,26 @@
+suite: test shared secret
+templates:
+  - secret-shared-secret.yaml
+values:
+  - values/embedded-charts-values.yaml
+tests:
+  - it: should base64 encode the provided shared secret
+    asserts:
+      - equal:
+          path: data.ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+          value: c2VjcmV0
+  - it: should fail when shared secret value is missing
+    set:
+      sharedSecret:
+        value: null
+    asserts:
+      - failedTemplate:
+          errorMessage: ".sharedSecret.value is mandatory when not using existingSecret"
+  - it: should not render when existingSecret is set
+    set:
+      sharedSecret:
+        existingSecret:
+          name: my-shared-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/alfresco-search-community/tests/service_test.yaml
+++ b/charts/alfresco-search-community/tests/service_test.yaml
@@ -1,0 +1,40 @@
+suite: test service
+templates:
+  - service.yaml
+tests:
+  - it: render default service
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            port: 8080
+            targetPort: http
+            protocol: TCP
+            name: http
+  - it: render modified service
+    set:
+      service.type: NodePort
+      service.port: 2222
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - contains:
+          path: spec.ports
+          content:
+            port: 2222
+            targetPort: http
+            protocol: TCP
+            name: http
+  - it: should render service annotations
+    set:
+      service.annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/charts/alfresco-search-community/tests/serviceaccount_test.yaml
+++ b/charts/alfresco-search-community/tests/serviceaccount_test.yaml
@@ -1,0 +1,32 @@
+suite: test serviceaccount
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should not have been rendered when disabled
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: render default serviceaccount
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+  - it: should render labels for serviceaccount
+    set:
+      nameOverride: testName
+    chart:
+      version: 1.0.0
+      appVersion: 2.0.0
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/component: alfresco-search-community
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: testName
+            app.kubernetes.io/version: 2.0.0
+            helm.sh/chart: alfresco-search-community-1.0.0

--- a/charts/alfresco-search-community/tests/values/embedded-charts-values.yaml
+++ b/charts/alfresco-search-community/tests/values/embedded-charts-values.yaml
@@ -1,0 +1,12 @@
+index:
+  url: http://elasticsearch:9200
+db:
+  url: jdbc:postgresql://postgresql:5432/alfresco
+  username: alfresco
+  password: alfresco
+repository:
+  url: http://alfresco:8080
+transform:
+  url: http://transform-core-aio:8090/transform/config
+sharedSecret:
+  value: secret

--- a/charts/alfresco-search-community/values.yaml
+++ b/charts/alfresco-search-community/values.yaml
@@ -1,0 +1,170 @@
+# -- The batch indexing component is a singleton; this value must remain 1
+# (a second instance conflicts on the shared watermark and self-terminates)
+replicaCount: 1
+
+global:
+  alfrescoRegistryPullSecrets: quay-registry-secret
+  # -- Global additional labels that can be set at parent/umbrella chart level
+  # These will be merged with chart-level additionalLabels, with chart-level taking precedence
+  additionalLabels: {}
+
+image:
+  repository: docker.io/alfresco/alfresco-elasticsearch-batch-indexing
+  pullPolicy: IfNotPresent
+  tag: 5.7.0-A.5
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+# -- Additional labels to be added to all resources (deployments, services, pods, etc.)
+# Example:
+#   Product: k8s
+#   Environment: DEV
+additionalLabels: {}
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health
+    port: http
+  initialDelaySeconds: 120
+  timeoutSeconds: 60
+readinessProbe:
+  httpGet:
+    path: /actuator/health
+    port: http
+  initialDelaySeconds: 60
+  timeoutSeconds: 60
+
+# -- Name of the search index, usually created by the repository
+indexName: alfresco
+
+# -- Set additional environment variables for the batch indexing container
+# (e.g. `ALFRESCO_REINDEX_*` tunables or `JAVA_OPTS`)
+environment: {}
+
+index:
+  # -- The URL where the elasticsearch service is available
+  url: null
+  # -- The username required to access the elasticsearch service, if any
+  username: null
+  # -- The password required to access the elasticsearch service, if any
+  password: null
+  existingConfigMap:
+    # -- Alternatively, provide elasticsearch service connection details via
+    # an existing configmap
+    name: null
+    keys:
+      # -- Key within the configmap holding the URL of the elasticsearch service
+      url: SEARCH_URL
+  existingSecret:
+    # -- Alternatively, provide elasticsearch credentials via an existing secret
+    name: null
+    keys:
+      # -- Key within the secret that holds the elasticsearch username
+      username: SEARCH_USERNAME
+      # -- Key within the secret that holds the elasticsearch password
+      password: SEARCH_PASSWORD
+
+db:
+  # -- Provide the full JDBC url to connect to database service e.g.:
+  # `jdbc:postgresql://hostname:5432/database`
+  url: null
+  # -- The username required to access the database service
+  username: null
+  # -- The password required to access the database service
+  password: null
+  existingSecret:
+    # -- Alternatively, provide database credentials via an existing secret
+    name: null
+    keys:
+      # -- Key within the secret holding the database username
+      username: DATABASE_USERNAME
+      # -- Key within the secret holding the database password
+      password: DATABASE_PASSWORD
+  existingConfigMap:
+    # -- Alternatively, provide database connection details via an existing
+    # configmap
+    name: null
+    keys:
+      # -- Key within the configmap holding the full JDBC url to connect to
+      # database service
+      url: DATABASE_URL
+
+repository:
+  # -- URL of the Alfresco repository (ACS)
+  url: null
+  existingConfigMap:
+    # -- Alternatively, provide repository connection details via an existing
+    # configmap
+    name: null
+    keys:
+      # -- Key within the configmap holding the full url to connect to the
+      # alfresco repository
+      url: REPOSITORY_URL
+
+transform:
+  # -- URL of the alfresco transform config endpoint (e.g.
+  # `http://transform-core-aio:8090/transform/config`)
+  url: null
+  existingConfigMap:
+    # -- Alternatively, provide transform config endpoint details via an
+    # existing configmap
+    name: null
+    keys:
+      # -- Key within the configmap holding the URL of the transform config
+      # endpoint
+      url: TRANSFORM_URL
+
+sharedSecret:
+  # -- Shared secret used to authenticate content requests against the
+  # repository (must match the repository's `solr.sharedSecret`)
+  value: null
+  existingSecret:
+    # -- Alternatively, provide the shared secret via an existing secret
+    name: null
+    keys:
+      # -- Key within the secret holding the shared secret
+      sharedSecret: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+resources:
+  requests:
+    cpu: "0.5"
+    memory: "256Mi"
+  limits:
+    cpu: "2"
+    memory: "2048Mi"
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/alfresco-search-community/values.yaml
+++ b/charts/alfresco-search-community/values.yaml
@@ -12,6 +12,8 @@ image:
   repository: docker.io/alfresco/alfresco-elasticsearch-batch-indexing
   pullPolicy: IfNotPresent
   tag: 5.7.0-A.5
+  # -- Port the container listens on
+  internalPort: 8080
 
 imagePullSecrets: []
 nameOverride: ""

--- a/test-deps.yaml
+++ b/test-deps.yaml
@@ -34,6 +34,9 @@ charts:
   alfresco-connector-msteams: []
   alfresco-repository:
     - postgresql
+  alfresco-search-community:
+    - postgresql
+    - elasticsearch
   alfresco-search-enterprise:
     - activemq
     - elasticsearch


### PR DESCRIPTION
Adds a new `charts/alfresco-search-community` Helm chart deploying the Community Elasticsearch batch indexing component (`alfresco-elasticsearch-batch-indexing`), the Community counterpart to the Enterprise `alfresco-search-enterprise` connector. It is modelled on the existing `alfresco-audit-storage` single-Deployment chart and reuses `alfresco-common` helpers.

## What it deploys

The batch indexing component is a long-running singleton Spring Boot service (`replicaCount` fixed at 1) that polls the Alfresco PostgreSQL database directly and bulk-upserts nodes into Elasticsearch. Unlike the Enterprise connector it does not use ActiveMQ or the Shared File Store. Image `docker.io/alfresco/alfresco-elasticsearch-batch-indexing:5.7.0-A.5`, container port 8080.

The chart wires the database (`SPRING_DATASOURCE_*`), Elasticsearch (`SPRING_ELASTICSEARCH_REST_*`, `ELASTICSEARCH_INDEXNAME`), the ACS repository URL (`ALFRESCO_ACS_URL`), the transform config cache (`ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL`) and the content transform shared secret (`ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET`), each following the repo's value-or-`existingConfigMap`/`existingSecret` convention. A passthrough `environment` map exposes the `ALFRESCO_REINDEX_*` tunables and `JAVA_OPTS`.

## Follow-up fixes

- Added `image.internalPort` so the container's listening port no longer tracks `.Values.service.port` — previously changing the Service's exposed port also changed the container's actual port and broke Service routing.
- Fixed `configmap-es.yaml`/`secret-es.yaml` to honor `index.existingConfigMap.keys.url` and `index.existingSecret.keys.*` instead of hardcoding `SEARCH_URL`/`SEARCH_USERNAME`/`SEARCH_PASSWORD`, matching the equivalent database templates. Overriding those key names without pointing at an existing ConfigMap/Secret previously produced a Deployment referencing a key the generated resource didn't contain.
- Chart version set to `0.1.0-alpha.0` to mark it as pre-release, matching the convention used for other new/major chart versions in this repo.

## CI / testing

Registered in `test-deps.yaml` with `postgresql` + `elasticsearch` dependencies. The chart-testing probes are relaxed to a plain TCP check in `ci/default-values.yaml`, because the component needs the repository-managed Alfresco DB schema (`alf_node`, ...) to report healthy on `/actuator/health`, which is not available under chart-testing; production users keep the real health probes. Helm unit tests cover the rendered templates and README is generated via helm-docs.

Verified locally: `helm unittest`, `ct lint`, and a full `helm install --wait` on a kind cluster with the postgres and elasticsearch dependencies (pod reaches `1/1 Running`).

OPSEXP-4173
