### PR TITLE
OPSEXP-4173 Bump Helm version to v4.2.3, update yamllint config, and fix trailing blank lines

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ on:
 
 env:
   TEST_ALL_CHARTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci-test-all') && 'true' || 'false' }}
-  HELM_VERSION: v4.1.1
+  HELM_VERSION: v4.2.3
   CHART_TESTING_VERSION: v3.14.0
 jobs:
   list-changed:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,3 +4,6 @@ rules:
   line-length: disable
   indentation: disable
   trailing-spaces: disable
+  empty-lines:
+    max: 2
+    max-end: 1

--- a/charts/alfresco-connector-hxi/Chart.yaml
+++ b/charts/alfresco-connector-hxi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-connector-hxi
 description: A Helm chart for deploying Alfresco connector hxi services
 type: application
-version: 0.9.0-alpha.0
+version: 0.9.0-alpha.1
 appVersion: 2.0.2
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-connector-hxi/Chart.yaml
+++ b/charts/alfresco-connector-hxi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-connector-hxi
 description: A Helm chart for deploying Alfresco connector hxi services
 type: application
-version: 0.8.0
+version: 0.9.0-alpha.0
 appVersion: 2.0.2
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-connector-hxi/README.md
+++ b/charts/alfresco-connector-hxi/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-connector-hxi
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 0.9.0-alpha.0](https://img.shields.io/badge/Version-0.9.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco connector hxi services
 

--- a/charts/alfresco-connector-hxi/README.md
+++ b/charts/alfresco-connector-hxi/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-connector-hxi
 
-![Version: 0.9.0-alpha.0](https://img.shields.io/badge/Version-0.9.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 0.9.0-alpha.1](https://img.shields.io/badge/Version-0.9.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco connector hxi services
 

--- a/charts/alfresco-connector-hxi/templates/deployment-connector-hxi-prediction-applier.yaml
+++ b/charts/alfresco-connector-hxi/templates/deployment-connector-hxi-prediction-applier.yaml
@@ -66,4 +66,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{ end }}
+{{- end }}

--- a/charts/alfresco-connector-hxi/templates/job-connector-hxi-bulk-ingester.yaml
+++ b/charts/alfresco-connector-hxi/templates/job-connector-hxi-bulk-ingester.yaml
@@ -79,4 +79,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{ end }}
+{{- end }}

--- a/charts/alfresco-connector-hxi/templates/svc-connector-hxi-prediction-applier.yaml
+++ b/charts/alfresco-connector-hxi/templates/svc-connector-hxi-prediction-applier.yaml
@@ -17,4 +17,4 @@ spec:
       name: {{ .Values.predictionApplier.service.name }}
   selector:
     {{- include "alfresco-connector-hxi.prediction-applier.selectorLabels" . | nindent 4 }}
-{{ end }}
+{{- end }}

--- a/charts/alfresco-search-enterprise/Chart.yaml
+++ b/charts/alfresco-search-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-enterprise
 description: A Helm chart for deploying Alfresco Elasticsearch connector
 type: application
-version: 5.1.0
+version: 5.2.0-alpha.0
 appVersion: 5.6.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-enterprise
 
-![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.6.0](https://img.shields.io/badge/AppVersion-5.6.0-informational?style=flat-square)
+![Version: 5.2.0-alpha.0](https://img.shields.io/badge/Version-5.2.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.6.0](https://img.shields.io/badge/AppVersion-5.6.0-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Elasticsearch connector
 

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -123,4 +123,4 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{ end }}
+{{- end }}

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   sure to deploy your own enterprise grade PostgreSQL instance and configure
   Alfresco charts to point to it.
 type: application
-version: 0.6.0
+version: 0.7.0-alpha.0
 appVersion: "17.9"
 dependencies:
   - name: alfresco-common

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -1,6 +1,6 @@
 # postgres
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.9](https://img.shields.io/badge/AppVersion-17.9-informational?style=flat-square)
+![Version: 0.7.0-alpha.0](https://img.shields.io/badge/Version-0.7.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.9](https://img.shields.io/badge/AppVersion-17.9-informational?style=flat-square)
 
 WARNING: This chart is meant to ease initial deployment for TESTING purposes.
 DO NOT use this chart in any staging, or production environment. It has very

--- a/charts/postgres/templates/service.yaml
+++ b/charts/postgres/templates/service.yaml
@@ -18,4 +18,4 @@ spec:
       name: tcp-postgresql
   selector:
     {{- include "postgres.selectorLabels" $ | nindent 4 }}
-{{ end }}
+{{- end }}


### PR DESCRIPTION
## Summary

Bumps the `HELM_VERSION` used in the lint-test workflow from v4.1.1 to v4.2.3, and updates `.yamllint.yml` to allow up to two consecutive blank lines with a single trailing blank line, matching the output produced by `helm template`/chart rendering. Split out of #637 so that PR only contains the new chart.

Running with the `ci-test-all` label surfaced a latent bug in `postgres`, `alfresco-connector-hxi`, and `alfresco-search-enterprise`: their root templates close with an un-trimmed `{{ end }}`, so `helm template --output-dir` renders two trailing blank lines instead of the single one every other chart produces, which even the loosened `empty-lines` rule rejects. Fixed by hyphen-trimming that final `end` (`{{- end }}`) in `postgres/templates/service.yaml`, `alfresco-connector-hxi/templates/job-connector-hxi-bulk-ingester.yaml`, `alfresco-connector-hxi/templates/svc-connector-hxi-prediction-applier.yaml`, `alfresco-connector-hxi/templates/deployment-connector-hxi-prediction-applier.yaml`, and `alfresco-search-enterprise/templates/reindexing-job.yaml`, and bumped each touched chart to its next alpha version.

## Test plan

- [x] Rendered and linted `postgres`, `alfresco-connector-hxi`, and `alfresco-search-enterprise` locally with `.yamllint.yml` after the trim fix, confirming the `empty-lines` errors are gone
- [ ] CI green on this PR

OPSEXP-4173