### PR TITLE
OPSEXP-4173 Relax alfresco-connector-hxi CI probes to TCP checks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -218,6 +218,12 @@ When working on changes to any chart (e.g., `charts/alfresco-repository/`, `char
 - **Pre-release versions**: Use semantic versioning pre-release identifiers (e.g., "1.0.0-alpha.1")
 - **Coordination with releases**: Version bumps trigger chart releases through CI/CD
 
+#### Alpha version requests
+
+If asked to bump a chart to an alpha version, bump to the next minor version
+with an `-alpha.0` suffix (e.g. `0.8.0` → `0.9.0-alpha.0`), regardless of the
+underlying change's own semver category.
+
 ### Chart Dependencies
 
 Some charts depend on others (e.g., many charts depend on `alfresco-common`). When updating:

--- a/charts/alfresco-connector-hxi/Chart.yaml
+++ b/charts/alfresco-connector-hxi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-connector-hxi
 description: A Helm chart for deploying Alfresco connector hxi services
 type: application
-version: 0.8.0
+version: 0.9.0-alpha.0
 appVersion: 2.0.2
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-connector-hxi/README.md
+++ b/charts/alfresco-connector-hxi/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-connector-hxi
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 0.9.0-alpha.0](https://img.shields.io/badge/Version-0.9.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco connector hxi services
 
@@ -33,6 +33,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | bulkIngester.image.pullPolicy | string | `"IfNotPresent"` |  |
 | bulkIngester.image.repository | string | `"quay.io/alfresco/alfresco-hxinsight-connector-bulk-ingester"` |  |
 | bulkIngester.image.tag | string | `"2.0.2"` |  |
+| bulkIngester.initContainers.waitForRepository.enabled | bool | `true` |  |
 | bulkIngester.initContainers.waitForRepository.image.pullPolicy | string | `"IfNotPresent"` |  |
 | bulkIngester.initContainers.waitForRepository.image.repository | string | `"curlimages/curl"` |  |
 | bulkIngester.initContainers.waitForRepository.image.tag | string | `"8.11.0"` |  |

--- a/charts/alfresco-connector-hxi/ci/default-values.yaml
+++ b/charts/alfresco-connector-hxi/ci/default-values.yaml
@@ -1,8 +1,7 @@
-# Both live-ingester and prediction-applier gate /actuator/health/readiness on
-# reaching the ACS repository, which chart-testing points at the public
-# https://httpbin.org/status/204 as a stand-in; when that third-party endpoint
-# is slow or unavailable the probe never turns healthy. Relax to a plain TCP
-# check so the workload is validated as started instead.
+# No real Alfresco Repository is deployed for this chart's tests, so
+# live-ingester/prediction-applier readiness (which depends on reaching it) is
+# relaxed to a plain TCP check, and bulk-ingester's wait-for-repository init
+# container (which blocks on an HTTP 200 from it) is disabled.
 liveIngester:
   replicaCount: 1
   resources:
@@ -32,6 +31,9 @@ bulkIngester:
     limits:
       cpu: "1"
       memory: "1Gi"
+  initContainers:
+    waitForRepository:
+      enabled: false
 predictionApplier:
   replicaCount: 1
   resources:
@@ -60,7 +62,7 @@ messageBroker:
   username: admin
   password: admin
 repository:
-  url: https://httpbin.org/status/204
+  url: http://repository
   versionOverride: '23.3.0'
 ats:
   sfsUrl: http://alfresco-transform-services-sfs

--- a/charts/alfresco-connector-hxi/ci/default-values.yaml
+++ b/charts/alfresco-connector-hxi/ci/default-values.yaml
@@ -1,3 +1,8 @@
+# Both live-ingester and prediction-applier gate /actuator/health/readiness on
+# reaching the ACS repository, which chart-testing points at the public
+# https://httpbin.org/status/204 as a stand-in; when that third-party endpoint
+# is slow or unavailable the probe never turns healthy. Relax to a plain TCP
+# check so the workload is validated as started instead.
 liveIngester:
   replicaCount: 1
   resources:
@@ -7,6 +12,18 @@ liveIngester:
     limits:
       cpu: "1"
       memory: "500Mi"
+  livenessProbe:
+    httpGet: null
+    tcpSocket:
+      port: 8080
+    initialDelaySeconds: 60
+    periodSeconds: 30
+  readinessProbe:
+    httpGet: null
+    tcpSocket:
+      port: 8080
+    initialDelaySeconds: 30
+    periodSeconds: 30
 bulkIngester:
   resources:
     requests:
@@ -24,6 +41,18 @@ predictionApplier:
     limits:
       cpu: "1"
       memory: "1Gi"
+  livenessProbe:
+    httpGet: null
+    tcpSocket:
+      port: 8080
+    initialDelaySeconds: 60
+    periodSeconds: 30
+  readinessProbe:
+    httpGet: null
+    tcpSocket:
+      port: 8080
+    initialDelaySeconds: 30
+    periodSeconds: 30
 db:
   url: jdbc:postgresql://postgresql:5432/alfresco
 messageBroker:

--- a/charts/alfresco-connector-hxi/templates/job-connector-hxi-bulk-ingester.yaml
+++ b/charts/alfresco-connector-hxi/templates/job-connector-hxi-bulk-ingester.yaml
@@ -40,6 +40,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+      {{- if .Values.bulkIngester.initContainers.waitForRepository.enabled }}
       initContainers:
         - name: wait-for-repository
           {{- with .Values.bulkIngester.initContainers.waitForRepository }}
@@ -67,6 +68,7 @@ spec:
               echo 'Alfresco is ready, delay reindexing to give a chance to fully initialise.'
               sleep 30
               echo 'Bulk ingesting started!'
+      {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/alfresco-connector-hxi/tests/job_test.yaml
+++ b/charts/alfresco-connector-hxi/tests/job_test.yaml
@@ -15,6 +15,16 @@ tests:
           path: spec.template.spec.initContainers[0].imagePullPolicy
           value: IfNotPresent
 
+  - it: should omit the init container when disabled
+    set:
+      bulkIngester:
+        initContainers:
+          waitForRepository:
+            enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
+
   - it: should render labels for job
     chart:
       version: 1.0.0

--- a/charts/alfresco-connector-hxi/values.yaml
+++ b/charts/alfresco-connector-hxi/values.yaml
@@ -105,6 +105,7 @@ bulkIngester:
     ALFRESCO_BULK_INGEST_PUBLISHER_ENDPOINT: activemq:queue:bulk-ingester-events
   initContainers:
     waitForRepository:
+      enabled: true
       image:
         repository: curlimages/curl
         tag: "8.11.0"


### PR DESCRIPTION
## Summary

Found while investigating the failing `install (charts/alfresco-connector-hxi)` job on PR #637's CI run: that failure is unrelated to the `alfresco-search-community` chart under review there, since alfresco-connector-hxi is not touched by that PR at all (it only surfaces because a repo-wide config change causes the full chart matrix to run).

`charts/alfresco-connector-hxi/ci/default-values.yaml` pointed `repository.url` at the public `https://httpbin.org/status/204` as a stand-in ACS repository for chart-testing, since no real Alfresco Repository is deployed for this chart's tests. That endpoint is now offline, and it fed two independent problems:

- The `prediction-applier` and `live-ingester` containers gate `/actuator/health/readiness` on an `AcsHealthProbe` reaching the repository URL, so the pods sit logging `ACS is not available. Retrying in 30 seconds` indefinitely and `ct install` eventually fails with `Progress deadline exceeded`.
- The `bulk-ingester` Job's `wait-for-repository` init container loops forever on `curl`ing the repository URL until it gets an HTTP 200, which it never received from `httpbin.org` either (that endpoint 404s on the actual probe path used), so the Job's pod was permanently stuck `PodInitializing`.

Fixes, both scoped to `ci/default-values.yaml` only (production defaults in `values.yaml` are untouched):
- Relax the `prediction-applier`/`live-ingester` probes to plain TCP checks, mirroring the existing precedent in `alfresco-search-community`'s `ci/default-values.yaml` for the same class of problem (readiness depending on state not achievable in chart-testing).
- Make the `bulk-ingester` `wait-for-repository` init container toggleable via a new `bulkIngester.initContainers.waitForRepository.enabled` value (defaults to `true`, unchanged behavior in production) and disable it in CI, since there's nothing for it to wait for.
- Drop the dead `httpbin.org` URL in favor of a harmless placeholder now that nothing depends on it being reachable.

Also bumped the chart to `0.9.0-alpha.0` and documented the "alpha bump = next minor + `-alpha.0`" convention in `.github/copilot-instructions.md`.

## Test plan

- [x] `helm lint charts/alfresco-connector-hxi -f charts/alfresco-connector-hxi/ci/default-values.yaml` passes
- [x] `helm template` confirms both probes render as pure `tcpSocket` checks with no leftover `httpGet`, and the `wait-for-repository` init container is omitted under CI values but still renders by default
- [ ] CI `install (charts/alfresco-connector-hxi)` job goes green on this PR

OPSEXP-4173