### PR TITLE
OPSEXP-4174 Disable content media types cache by default in alfresco-search-community

### DIFF
--- a/charts/alfresco-search-community/Chart.yaml
+++ b/charts/alfresco-search-community/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-community
 description: A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 type: application
-version: 0.1.0-alpha.0
+version: 0.1.0-alpha.1
 appVersion: 5.7.0-A.5
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-community
 
-![Version: 0.1.0-alpha.0](https://img.shields.io/badge/Version-0.1.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0-A.5](https://img.shields.io/badge/AppVersion-5.7.0--A.5-informational?style=flat-square)
+![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0-A.5](https://img.shields.io/badge/AppVersion-5.7.0--A.5-informational?style=flat-square)
 
 A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 
@@ -31,7 +31,8 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | db.password | string | `nil` | The password required to access the database service |
 | db.url | string | `nil` | Provide the full JDBC url to connect to database service e.g.: `jdbc:postgresql://hostname:5432/database` |
 | db.username | string | `nil` | The username required to access the database service |
-| environment | object | `{}` | Set additional environment variables for the batch indexing container (e.g. `ALFRESCO_REINDEX_*` tunables or `JAVA_OPTS`) |
+| environment | object | `{"ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_ENABLED":"false"}` | Set additional environment variables for the batch indexing container (e.g. `ALFRESCO_REINDEX_*` tunables or `JAVA_OPTS`) |
+| environment.ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_ENABLED | string | `"false"` | Disable the accepted content media types cache: it requires a single endpoint exposing all renderers (ATS all-in-one), which is not how transform components are deployed on Kubernetes |
 | fullnameOverride | string | `""` |  |
 | global.additionalLabels | object | `{}` | Global additional labels that can be set at parent/umbrella chart level These will be merged with chart-level additionalLabels, with chart-level taking precedence |
 | global.alfrescoRegistryPullSecrets | string | `"quay-registry-secret"` |  |
@@ -78,12 +79,12 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| sharedSecret.existingSecret.keys.sharedSecret | string | `"ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET"` | Key within the secret holding the shared secret |
-| sharedSecret.existingSecret.name | string | `nil` | Alternatively, provide the shared secret via an existing secret |
-| sharedSecret.value | string | `nil` | Shared secret used to authenticate content requests against the repository (must match the repository's `solr.sharedSecret`) |
 | tolerations | list | `[]` |  |
 | transform.existingConfigMap.keys.url | string | `"TRANSFORM_URL"` | Key within the configmap holding the URL of the transform config endpoint |
 | transform.existingConfigMap.name | string | `nil` | Alternatively, provide transform config endpoint details via an existing configmap |
-| transform.url | string | `nil` | URL of the alfresco transform config endpoint (e.g. `http://transform-core-aio:8090/transform/config`) |
+| transform.sharedSecret.existingSecret.keys.sharedSecret | string | `"ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET"` | Key within the secret holding the shared secret |
+| transform.sharedSecret.existingSecret.name | string | `nil` | Alternatively, provide the shared secret via an existing secret |
+| transform.sharedSecret.value | string | `"notused"` | Shared secret authenticating the accepted content media types cache query against the repository. Only used when that cache is enabled (disabled by default) |
+| transform.url | string | `"http://transform-core-aio:8090/transform/config"` | URL of the alfresco transform config endpoint. Only queried when the accepted content media types cache is enabled (disabled by default, see the environment section); a value is nonetheless required by the chart |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/alfresco-search-community/ci/default-values.yaml
+++ b/charts/alfresco-search-community/ci/default-values.yaml
@@ -10,8 +10,8 @@ repository:
   url: http://alfresco:8080
 transform:
   url: http://transform-core-aio:8090/transform/config
-sharedSecret:
-  value: secret
+  sharedSecret:
+    value: secret
 # The batch indexing component needs the Alfresco DB schema (created by the
 # repository) to become healthy, which is not available in chart-testing. Relax
 # the probes to a plain TCP check so the workload is validated as started.

--- a/charts/alfresco-search-community/templates/_helpers-config.tpl
+++ b/charts/alfresco-search-community/templates/_helpers-config.tpl
@@ -11,7 +11,7 @@ Usage: include "alfresco-search-community.config.env" $
 {{- $transformCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "transform")) "Chart" .Chart "Release" .Release }}
 {{- $transformCm := coalesce .Values.transform.existingConfigMap.name (include "alfresco-search-community.fullname" $transformCtx) }}
 {{- $secretCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "shared-secret")) "Chart" .Chart "Release" .Release }}
-{{- $sharedSecret := coalesce .Values.sharedSecret.existingSecret.name (include "alfresco-search-community.fullname" $secretCtx) }}
+{{- $sharedSecret := coalesce .Values.transform.sharedSecret.existingSecret.name (include "alfresco-search-community.fullname" $secretCtx) }}
 - name: ELASTICSEARCH_INDEXNAME
   value: {{ .Values.indexName | quote }}
 - name: ALFRESCO_ACS_URL
@@ -28,5 +28,5 @@ Usage: include "alfresco-search-community.config.env" $
   valueFrom:
     secretKeyRef:
       name: {{ $sharedSecret }}
-      key: {{ .Values.sharedSecret.existingSecret.keys.sharedSecret }}
+      key: {{ .Values.transform.sharedSecret.existingSecret.keys.sharedSecret }}
 {{- end -}}

--- a/charts/alfresco-search-community/templates/secret-shared-secret.yaml
+++ b/charts/alfresco-search-community/templates/secret-shared-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.sharedSecret.existingSecret.name }}
+{{- if not .Values.transform.sharedSecret.existingSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +8,5 @@ metadata:
     {{- include "alfresco-search-community.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  {{ .Values.sharedSecret.existingSecret.keys.sharedSecret }}: {{ required ".sharedSecret.value is mandatory when not using existingSecret" .Values.sharedSecret.value | b64enc | quote }}
+  {{ .Values.transform.sharedSecret.existingSecret.keys.sharedSecret }}: {{ required ".transform.sharedSecret.value is mandatory when not using existingSecret" .Values.transform.sharedSecret.value | b64enc | quote }}
 {{- end }}

--- a/charts/alfresco-search-community/tests/deployment_test.yaml
+++ b/charts/alfresco-search-community/tests/deployment_test.yaml
@@ -141,6 +141,13 @@ tests:
               secretKeyRef:
                 key: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
                 name: RELEASE-NAME-alfresco-search-community-shared-secret
+  - it: should disable the accepted content media types cache by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_ENABLED
+            value: "false"
   - it: should wire envs from external configmaps and secrets
     set:
       index:
@@ -173,11 +180,11 @@ tests:
           name: transform-external-config
           keys:
             url: TRANSFORM_URL_EXTERNAL
-      sharedSecret:
-        existingSecret:
-          name: shared-secret-external
-          keys:
-            sharedSecret: SHARED_SECRET_EXTERNAL
+        sharedSecret:
+          existingSecret:
+            name: shared-secret-external
+            keys:
+              sharedSecret: SHARED_SECRET_EXTERNAL
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/alfresco-search-community/tests/secret-shared-secret_test.yaml
+++ b/charts/alfresco-search-community/tests/secret-shared-secret_test.yaml
@@ -11,16 +11,18 @@ tests:
           value: c2VjcmV0
   - it: should fail when shared secret value is missing
     set:
-      sharedSecret:
-        value: null
+      transform:
+        sharedSecret:
+          value: null
     asserts:
       - failedTemplate:
-          errorMessage: ".sharedSecret.value is mandatory when not using existingSecret"
+          errorMessage: ".transform.sharedSecret.value is mandatory when not using existingSecret"
   - it: should not render when existingSecret is set
     set:
-      sharedSecret:
-        existingSecret:
-          name: my-shared-secret
+      transform:
+        sharedSecret:
+          existingSecret:
+            name: my-shared-secret
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/alfresco-search-community/tests/values/embedded-charts-values.yaml
+++ b/charts/alfresco-search-community/tests/values/embedded-charts-values.yaml
@@ -8,5 +8,5 @@ repository:
   url: http://alfresco:8080
 transform:
   url: http://transform-core-aio:8090/transform/config
-sharedSecret:
-  value: secret
+  sharedSecret:
+    value: secret

--- a/charts/alfresco-search-community/values.yaml
+++ b/charts/alfresco-search-community/values.yaml
@@ -42,7 +42,11 @@ indexName: alfresco
 
 # -- Set additional environment variables for the batch indexing container
 # (e.g. `ALFRESCO_REINDEX_*` tunables or `JAVA_OPTS`)
-environment: {}
+environment:
+  # -- Disable the accepted content media types cache: it requires a single
+  # endpoint exposing all renderers (ATS all-in-one), which is not how transform
+  # components are deployed on Kubernetes
+  ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_ENABLED: "false"
 
 index:
   # -- The URL where the elasticsearch service is available
@@ -105,9 +109,10 @@ repository:
       url: REPOSITORY_URL
 
 transform:
-  # -- URL of the alfresco transform config endpoint (e.g.
-  # `http://transform-core-aio:8090/transform/config`)
-  url: null
+  # -- URL of the alfresco transform config endpoint. Only queried when the
+  # accepted content media types cache is enabled (disabled by default, see the
+  # environment section); a value is nonetheless required by the chart
+  url: http://transform-core-aio:8090/transform/config
   existingConfigMap:
     # -- Alternatively, provide transform config endpoint details via an
     # existing configmap
@@ -116,17 +121,17 @@ transform:
       # -- Key within the configmap holding the URL of the transform config
       # endpoint
       url: TRANSFORM_URL
-
-sharedSecret:
-  # -- Shared secret used to authenticate content requests against the
-  # repository (must match the repository's `solr.sharedSecret`)
-  value: null
-  existingSecret:
-    # -- Alternatively, provide the shared secret via an existing secret
-    name: null
-    keys:
-      # -- Key within the secret holding the shared secret
-      sharedSecret: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+  sharedSecret:
+    # -- Shared secret authenticating the accepted content media types cache
+    # query against the repository. Only used when that cache is enabled
+    # (disabled by default)
+    value: notused
+    existingSecret:
+      # -- Alternatively, provide the shared secret via an existing secret
+      name: null
+      keys:
+        # -- Key within the secret holding the shared secret
+        sharedSecret: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Disables the accepted content media types cache by default in the `alfresco-search-community` chart. On Kubernetes the transform components are deployed split, so there is no single endpoint exposing all supported renderers — that only exists with Alfresco Transform Service all-in-one (ATS AIO), which is neither the recommended k8s topology nor supported by this chart. The cache is therefore off by default (`ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_ENABLED: "false"`).

With the cache disabled the transform config endpoint is never queried, so `transform.url` and the shared secret that authenticates that request become inert. Both now ship harmless dummy defaults (`http://transform-core-aio:8090/transform/config` and `notused`) so the chart works out of the box without a real transform endpoint or secret. They remain honoured whenever the cache is re-enabled.

The shared secret value is nested under `transform` (`transform.sharedSecret`, previously top-level `sharedSecret`) to make its association with the transform config endpoint explicit. This is a breaking change to the values API, acceptable while the chart is still alpha.

Chart bumped to `0.1.0-alpha.1`. README regenerated via helm-docs, and a unit test added asserting the default env disables the cache.

OPSEXP-4174