### PR TITLE
OPSEXP-4219 Make createIndexTemplate init container resources mode-aware

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.8.0-alpha.0
+version: 1.8.0-alpha.1
 appVersion: 26.1.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.8.0-alpha.0](https://img.shields.io/badge/Version-1.8.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
+![Version: 1.8.0-alpha.1](https://img.shields.io/badge/Version-1.8.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.0](https://img.shields.io/badge/AppVersion-26.1.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 
@@ -163,8 +163,7 @@ The init container image is selected automatically based on the auth mode; overr
 | initContainers.createIndexTemplate.indexName | string | `"alfresco"` | Index name to apply the template to |
 | initContainers.createIndexTemplate.numberOfReplicas | int | `0` | Number of replicas for the index |
 | initContainers.createIndexTemplate.numberOfShards | int | `1` | Number of shards for the index |
-| initContainers.createIndexTemplate.resources.limits.cpu | string | `"250m"` |  |
-| initContainers.createIndexTemplate.resources.limits.memory | string | `"20Mi"` |  |
+| initContainers.createIndexTemplate.resources | object | `{"basic":{"limits":{"cpu":"250m","memory":"20Mi"}},"iam":{"limits":{"cpu":"250m","memory":"256Mi"}}}` | Init container resources per auth mode; the entry matching `auth.mode` is used. The `iam` awscurl image (Python + botocore) needs substantially more memory than the `basic` curl image. |
 | initContainers.createIndexTemplate.templateName | string | `"alfresco-template"` | Template name for the index template |
 | initContainers.waitDbReady.image.pullPolicy | string | `"IfNotPresent"` |  |
 | initContainers.waitDbReady.image.repository | string | `"busybox"` |  |

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -163,7 +163,10 @@ The init container image is selected automatically based on the auth mode; overr
 | initContainers.createIndexTemplate.indexName | string | `"alfresco"` | Index name to apply the template to |
 | initContainers.createIndexTemplate.numberOfReplicas | int | `0` | Number of replicas for the index |
 | initContainers.createIndexTemplate.numberOfShards | int | `1` | Number of shards for the index |
-| initContainers.createIndexTemplate.resources | object | `{"basic":{"limits":{"cpu":"250m","memory":"20Mi"}},"iam":{"limits":{"cpu":"250m","memory":"256Mi"}}}` | Init container resources per auth mode; the entry matching `auth.mode` is used. The `iam` awscurl image (Python + botocore) needs substantially more memory than the `basic` curl image. |
+| initContainers.createIndexTemplate.resources.basic.limits.cpu | string | `"250m"` |  |
+| initContainers.createIndexTemplate.resources.basic.limits.memory | string | `"20Mi"` |  |
+| initContainers.createIndexTemplate.resources.iam.limits.cpu | string | `"250m"` |  |
+| initContainers.createIndexTemplate.resources.iam.limits.memory | string | `"256Mi"` |  |
 | initContainers.createIndexTemplate.templateName | string | `"alfresco-template"` | Template name for the index template |
 | initContainers.waitDbReady.image.pullPolicy | string | `"IfNotPresent"` |  |
 | initContainers.waitDbReady.image.repository | string | `"busybox"` |  |

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- $image := index .images $mode }}
           image: {{ printf "%s:%s" $image.repository $image.tag | quote }}
           imagePullPolicy: {{ $image.pullPolicy }}
-          resources: {{- toYaml .resources | nindent 12 }}
+          resources: {{- toYaml (index .resources $mode) | nindent 12 }}
           {{- end }}
           {{- include "alfresco-common.component-security-context" .Values | indent 8 }}
           env:

--- a/charts/alfresco-repository/tests/create-index-template_test.yaml
+++ b/charts/alfresco-repository/tests/create-index-template_test.yaml
@@ -73,9 +73,10 @@ tests:
         createIndexTemplate:
           enabled: true
           resources:
-            limits:
-              cpu: "500m"
-              memory: "50Mi"
+            basic:
+              limits:
+                cpu: "500m"
+                memory: "50Mi"
     asserts:
       - equal:
           path: spec.template.spec.initContainers[1].name
@@ -86,6 +87,30 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[1].resources.limits.memory
           value: "50Mi"
+
+  - it: should default to 20Mi for basic auth
+    set:
+      initContainers:
+        createIndexTemplate:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].resources.limits.memory
+          value: "20Mi"
+
+  - it: should default to 256Mi for iam auth
+    set:
+      initContainers:
+        createIndexTemplate:
+          enabled: true
+          auth:
+            mode: iam
+            aws:
+              region: us-east-1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].resources.limits.memory
+          value: "256Mi"
 
   - it: should use configured template name and index name
     set:

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -382,10 +382,17 @@ initContainers:
         repository: ghcr.io/okigan/awscurl
         tag: "v0.44"
         pullPolicy: IfNotPresent
+    # -- Init container resources per auth mode; the entry matching `auth.mode` is used. The `iam`
+    # awscurl image (Python + botocore) needs substantially more memory than the `basic` curl image.
     resources:
-      limits:
-        cpu: "250m"
-        memory: "20Mi"
+      basic:
+        limits:
+          cpu: "250m"
+          memory: "20Mi"
+      iam:
+        limits:
+          cpu: "250m"
+          memory: "256Mi"
     # -- Template name for the index template
     templateName: alfresco-template
     # -- Index name to apply the template to

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -382,8 +382,6 @@ initContainers:
         repository: ghcr.io/okigan/awscurl
         tag: "v0.44"
         pullPolicy: IfNotPresent
-    # -- Init container resources per auth mode; the entry matching `auth.mode` is used. The `iam`
-    # awscurl image (Python + botocore) needs substantially more memory than the `basic` curl image.
     resources:
       basic:
         limits:


### PR DESCRIPTION
PR #640 added an `iam` auth mode to the `create-index-template` init container. In `basic` mode the container runs `curlimages/curl` (tiny); in `iam` mode it runs `ghcr.io/okigan/awscurl` (Python + botocore), which needs substantially more memory at startup. The chart applied a single flat `250m` / `20Mi` default regardless of mode, which is fine for `curl` but OOMKills (`Terminated 137: OOMKilled`, ~4s in) the `awscurl` image, forcing every consumer to hardcode a memory override.

This restructures `initContainers.createIndexTemplate.resources` into a per-mode map keyed by auth mode, mirroring the existing `images` map. Defaults are `20Mi` for `basic` and `256Mi` for `iam`, so consumers get a sane value out of the box without a local override.

This is a breaking change to the `resources` value shape (flat → keyed by mode): overrides move from `resources.limits.*` to `resources.<mode>.limits.*`. The feature only exists in the unreleased `1.8.0-alpha.0` pre-release, so no released consumer is affected. Chart version bumped to `1.8.0-alpha.1`.

Unit tests cover both modes' defaults (the iam `256Mi` case guards the OOMKill regression) plus the updated override path.

OPSEXP-4219