### PR TITLE
OPSEXP-4208 Release alfresco-search-community 0.1.0

### DIFF
--- a/charts/alfresco-search-community/Chart.yaml
+++ b/charts/alfresco-search-community/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-community
 description: A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 type: application
-version: 0.1.0-alpha.1
+version: 0.1.0
 appVersion: 5.7.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-community/Chart.yaml
+++ b/charts/alfresco-search-community/Chart.yaml
@@ -4,7 +4,7 @@ name: alfresco-search-community
 description: A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 type: application
 version: 0.1.0-alpha.1
-appVersion: 5.7.0-A.5
+appVersion: 5.7.0
 dependencies:
   - name: alfresco-common
     version: 5.1.0

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-community
 
-![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
 
 A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-community
 
-![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0-A.5](https://img.shields.io/badge/AppVersion-5.7.0--A.5-informational?style=flat-square)
+![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
 
 A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 
@@ -39,7 +39,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | image.internalPort | int | `8080` | Port the container listens on |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/alfresco/alfresco-elasticsearch-batch-indexing"` |  |
-| image.tag | string | `"5.7.0-A.5"` |  |
+| image.tag | string | `"5.7.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | index.existingConfigMap.keys.url | string | `"SEARCH_URL"` | Key within the configmap holding the URL of the elasticsearch service |
 | index.existingConfigMap.name | string | `nil` | Alternatively, provide elasticsearch service connection details via an existing configmap |

--- a/charts/alfresco-search-community/values.yaml
+++ b/charts/alfresco-search-community/values.yaml
@@ -11,7 +11,7 @@ global:
 image:
   repository: docker.io/alfresco/alfresco-elasticsearch-batch-indexing
   pullPolicy: IfNotPresent
-  tag: 5.7.0-A.5
+  tag: 5.7.0
   # -- Port the container listens on
   internalPort: 8080
 

--- a/test-deps.yaml
+++ b/test-deps.yaml
@@ -5,7 +5,7 @@ deps:
   postgresql:
     chart: postgres
     repository: https://alfresco.github.io/alfresco-helm-charts/
-    version: 0.5.0
+    version: 0.6.0
   activemq:
     chart: activemq
     repository: https://alfresco.github.io/alfresco-helm-charts/
@@ -13,7 +13,7 @@ deps:
   elasticsearch:
     chart: elastic
     repository: https://alfresco.github.io/alfresco-helm-charts/
-    version: 0.6.0
+    version: 0.7.0
 
 charts:
   activemq: []


### PR DESCRIPTION
## Summary
- Merges the automated `updatecli-bump-acs` and `updatecli-bump-helm` bump branches, dropping the `alfresco-search-community` `appVersion` pre-release suffix (`5.7.0-A.5` -> `5.7.0`)
- Bumps the chart's own `version` to GA (`0.1.0-alpha.1` -> `0.1.0`) to match, and regenerates the chart README

## Test plan
- [x] `./scripts/charts.sh` passes (no GA chart depends on pre-release versions)
- [x] `helm kubeconform` passes for `alfresco-search-community`

OPSEXP-4208