### PR TITLE
OPSEXP-4226 Decouple repository Solr shared-secret from search flavor

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.8.0
+version: 1.9.0-alpha.0
 appVersion: 26.2.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
+![Version: 1.9.0-alpha.0](https://img.shields.io/badge/Version-1.9.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 
@@ -114,12 +114,12 @@ The init container image is selected automatically based on the auth mode; overr
 | configuration.search.existingConfigMap.keys.url | string | `"SEARCH_URL"` | Key within the configmap  holding the search service URL. |
 | configuration.search.existingConfigMap.name | string | `nil` | Optional configmap containing the search service URL |
 | configuration.search.existingSecret.keys.password | string | `"ELASTICSEARCH_PASSWORD"` | Key within the secret holding the search service password |
-| configuration.search.existingSecret.keys.solr-secret | string | `"SOLR_SECRET"` | Key within the secret holding the index shared secret |
+| configuration.search.existingSecret.keys.solr-secret | string | `"SOLR_SECRET"` | Key within the secret holding the legacy Solr tracking webscripts shared secret |
 | configuration.search.existingSecret.keys.username | string | `"ELASTICSEARCH_USERNAME"` | Key within the secret holding the search service username |
 | configuration.search.existingSecret.name | string | `nil` | Optional secret containing search service credentials |
 | configuration.search.flavor | string | `"noindex"` | Can be either `solr`, `elasticsearch` or `noindex` |
 | configuration.search.password | string | `nil` | Password to authenticate to the search service |
-| configuration.search.solr-secret | string | `nil` | Solr inter process shared secret |
+| configuration.search.solr-secret | string | `nil` | Shared secret protecting the repository's legacy Solr tracking webscripts API (`solr.secureComms`/`solr.sharedSecret`). Authenticates any indexer that still pulls metadata/renditions through that API (e.g. a Solr6 tracker, or the alfresco-search-community batch indexer), so it applies independently of the repository's own outbound query flavor. |
 | configuration.search.url | string | `nil` | URL where the search service can be found |
 | configuration.search.username | string | `nil` | Username to authenticate to the search service |
 | configuration.smtp | object | see below | Basic SMTP capabilities config (limited to enabling/disabling). In order to pass more SMTP properties and configure the subsystem more deeply, please use value `environment.CATALINA_OPTS` or `configuration.repository.existingConfigMap` and check the [available properties for this subsystem](https://github.com/Alfresco/alfresco-community-repo/blob/master/repository/src/main/resources/alfresco/subsystems/email/InboundSMTP/inboundSMTP.properties) |

--- a/charts/alfresco-repository/templates/_helpers-search.tpl
+++ b/charts/alfresco-repository/templates/_helpers-search.tpl
@@ -34,15 +34,16 @@ Usage: include "alfresco-repository.search.config" $
 */}}
 {{- define "alfresco-repository.search.config" -}}
 {{- with .Values.configuration.search }}
-  {{- if eq "solr6" (include "alfresco-repository.search.flavor.valid" .flavor) }}
+  {{- $flavor := include "alfresco-repository.search.flavor.valid" .flavor }}
+  {{- if and (ne "noindex" $flavor) (or .existingSecret.name (index . "solr-secret")) }}
+  -Dsolr.secureComms="secret"
+  -Dsolr.sharedSecret=$SOLR_SECRET
+  {{- end }}
+  {{- if eq "solr6" $flavor }}
   -Dsolr.host="$SEARCH_HOST"
   -Dsolr.port="$SEARCH_PORT"
   -Dsolr.base.url="$SOLR_BASE_URL"
-  -Dsolr.secureComms="$SEARCH_SECURECOMMS"
-  {{- if or .existingSecret.name (index . "solr-secret") }}
-  -Dsolr.sharedSecret=$SOLR_SECRET
-  {{- end }}
-  {{- else if eq "elasticsearch" (include "alfresco-repository.search.flavor.valid" .flavor) }}
+  {{- else if eq "elasticsearch" $flavor }}
   -Delasticsearch.host=$SEARCH_HOST
   -Delasticsearch.port=$SEARCH_PORT
   -Delasticsearch.secureComms=$SEARCH_SECURECOMMS

--- a/charts/alfresco-repository/templates/_helpers-search.tpl
+++ b/charts/alfresco-repository/templates/_helpers-search.tpl
@@ -34,16 +34,15 @@ Usage: include "alfresco-repository.search.config" $
 */}}
 {{- define "alfresco-repository.search.config" -}}
 {{- with .Values.configuration.search }}
-  {{- $flavor := include "alfresco-repository.search.flavor.valid" .flavor }}
-  {{- if and (ne "noindex" $flavor) (or .existingSecret.name (index . "solr-secret")) }}
-  -Dsolr.secureComms="secret"
-  -Dsolr.sharedSecret=$SOLR_SECRET
-  {{- end }}
-  {{- if eq "solr6" $flavor }}
+  {{- if eq "solr6" (include "alfresco-repository.search.flavor.valid" .flavor) }}
   -Dsolr.host="$SEARCH_HOST"
   -Dsolr.port="$SEARCH_PORT"
   -Dsolr.base.url="$SOLR_BASE_URL"
-  {{- else if eq "elasticsearch" $flavor }}
+  -Dsolr.secureComms="$SEARCH_SECURECOMMS"
+  {{- if or .existingSecret.name (index . "solr-secret") }}
+  -Dsolr.sharedSecret=$SOLR_SECRET
+  {{- end }}
+  {{- else if eq "elasticsearch" (include "alfresco-repository.search.flavor.valid" .flavor) }}
   -Delasticsearch.host=$SEARCH_HOST
   -Delasticsearch.port=$SEARCH_PORT
   -Delasticsearch.secureComms=$SEARCH_SECURECOMMS
@@ -51,6 +50,10 @@ Usage: include "alfresco-repository.search.config" $
   -Delasticsearch.password=$ELASTICSEARCH_PASSWORD
   {{- range $key, $val := .elasticsearchProperties }}
   -Delasticsearch.{{ $key }}={{ $val }}
+  {{- end }}
+  {{- if or .existingSecret.name (index . "solr-secret") }}
+  -Dsolr.secureComms="secret"
+  -Dsolr.sharedSecret=$SOLR_SECRET
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/alfresco-repository/templates/secret-search.yaml
+++ b/charts/alfresco-repository/templates/secret-search.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "alfresco-repository.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  {{- if eq .flavor "solr6" }}
+  {{- if index . "solr-secret" }}
   SOLR_SECRET: {{ index . "solr-secret" | b64enc | quote }}
   {{- end }}
   {{- if eq .flavor "elasticsearch" }}

--- a/charts/alfresco-repository/tests/search_test.yaml
+++ b/charts/alfresco-repository/tests/search_test.yaml
@@ -62,7 +62,12 @@ tests:
       - matchRegex:
           path: data.CATALINA_OPTS
           pattern: |-
-            (^\s*|[^\s]\s+)-Dsolr\.secureComms="\$SEARCH_SECURECOMMS"($|\s)
+            (^\s*|[^\s]\s+)-Dsolr\.secureComms="secret"($|\s)
+        template: configmap-repository.yaml
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.sharedSecret=\$SOLR_SECRET($|\s)
         template: configmap-repository.yaml
 
   - it: should render a working Solr6 config based on values (noauth)
@@ -77,6 +82,11 @@ tests:
           path: data.SEARCH_SECURECOMMS
           value: none
         template: configmap-search.yaml
+      - notMatchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.(secureComms|sharedSecret)
+        template: configmap-repository.yaml
 
   - it: should not render any search configmap
     set:
@@ -175,6 +185,33 @@ tests:
           pattern: |-
             (^\s*|[^\s]\s+)-Delasticsearch\.secureComms=\$SEARCH_SECURECOMMS($|\s)
         template: configmap-repository.yaml
+
+  - it: should render the legacy Solr shared secret alongside an ES flavor
+    set:
+      configuration:
+        search:
+          << : *esValues
+          solr-secret: mysupersecret
+    asserts:
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.secureComms="secret"($|\s)
+        template: configmap-repository.yaml
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.sharedSecret=\$SOLR_SECRET($|\s)
+        template: configmap-repository.yaml
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Delasticsearch\.secureComms=\$SEARCH_SECURECOMMS($|\s)
+        template: configmap-repository.yaml
+      - equal:
+          path: data.SOLR_SECRET
+          value: bXlzdXBlcnNlY3JldA==
+        template: secret-search.yaml
 
   - it: should render a working ES config based on values (noauth)
     set:

--- a/charts/alfresco-repository/tests/search_test.yaml
+++ b/charts/alfresco-repository/tests/search_test.yaml
@@ -62,7 +62,7 @@ tests:
       - matchRegex:
           path: data.CATALINA_OPTS
           pattern: |-
-            (^\s*|[^\s]\s+)-Dsolr\.secureComms="secret"($|\s)
+            (^\s*|[^\s]\s+)-Dsolr\.secureComms="\$SEARCH_SECURECOMMS"($|\s)
         template: configmap-repository.yaml
       - matchRegex:
           path: data.CATALINA_OPTS
@@ -85,7 +85,37 @@ tests:
       - notMatchRegex:
           path: data.CATALINA_OPTS
           pattern: |-
-            (^\s*|[^\s]\s+)-Dsolr\.(secureComms|sharedSecret)
+            (^\s*|[^\s]\s+)-Dsolr\.sharedSecret
+        template: configmap-repository.yaml
+
+  - it: solr6 secureComms is overridable via existingConfigMap independent of shared secret
+    set:
+      configuration:
+        search:
+          flavor: solr6
+          existingConfigMap:
+            name: mysolrcm
+            keys:
+              securecomms: INDEX_SERVICE_SECURITY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SEARCH_SECURECOMMS
+            valueFrom:
+              configMapKeyRef:
+                name: mysolrcm
+                key: INDEX_SERVICE_SECURITY
+        template: deployment.yaml
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.secureComms="\$SEARCH_SECURECOMMS"($|\s)
+        template: configmap-repository.yaml
+      - notMatchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.sharedSecret
         template: configmap-repository.yaml
 
   - it: should not render any search configmap

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -95,7 +95,11 @@ configuration:
     username: null
     # -- Password to authenticate to the search service
     password: null
-    # -- Solr inter process shared secret
+    # -- Shared secret protecting the repository's legacy Solr tracking
+    # webscripts API (`solr.secureComms`/`solr.sharedSecret`). Authenticates
+    # any indexer that still pulls metadata/renditions through that API (e.g.
+    # a Solr6 tracker, or the alfresco-search-community batch indexer), so it
+    # applies independently of the repository's own outbound query flavor.
     solr-secret: null
     # -- A map of additional elasticsearch.* properties to be passed as -D
     # arguments to the repository when search.flavor is set to elasticsearch.
@@ -133,7 +137,8 @@ configuration:
         username: ELASTICSEARCH_USERNAME
         # -- Key within the secret holding the search service password
         password: ELASTICSEARCH_PASSWORD
-        # -- Key within the secret holding the index shared secret
+        # -- Key within the secret holding the legacy Solr tracking
+        # webscripts shared secret
         solr-secret: SOLR_SECRET
 
     existingConfigMap:


### PR DESCRIPTION
## Summary

The `alfresco-repository` chart's `-Dsolr.secureComms`/`-Dsolr.sharedSecret` JVM options (and the backing `SOLR_SECRET` secret key) were only rendered when `configuration.search.flavor` was `solr6`. These properties actually protect a separate, legacy concern: the repository's old Solr tracking webscripts API, which any indexer that still speaks that protocol authenticates against — including the newer `alfresco-search-community` Elasticsearch-based batch indexer. As soon as a deployment switched flavor to `elasticsearch`, the repository silently stopped setting these properties and stopped creating the secret key, even though the batch indexer still needs that shared secret to authenticate against the repository's legacy tracking API.

This PR adds the missing shared-secret support to the `elasticsearch` branch, without touching `solr6`'s existing behavior: it now renders `-Dsolr.secureComms="secret"` and `-Dsolr.sharedSecret` whenever `existingSecret.name` or `solr-secret` is configured under `elasticsearch` flavor too (still nothing under `noindex`, which remains a full search-disable switch). The value is hardcoded to `"secret"` for the `elasticsearch` branch rather than reusing `$SEARCH_SECURECOMMS`, since that env var carries a different meaning per flavor (`secret`/`none` for the Solr6 query client vs `https`/`none` for Elasticsearch's own TLS mode) and would render the wrong value here. `solr6`'s own `-Dsolr.secureComms="$SEARCH_SECURECOMMS"` is left exactly as it was, preserving the ability to override it to an arbitrary value via `existingConfigMap` independent of whether a shared secret is set.

- `templates/_helpers-search.tpl`: add the shared-secret JVM options to the `elasticsearch` branch; `solr6` unchanged
- `templates/secret-search.yaml`: write `SOLR_SECRET` whenever `solr-secret` is set, not just under `solr6`
- `values.yaml`: clarify doc comments; regenerated `README.md`
- `tests/search_test.yaml`: added coverage for `elasticsearch` + shared secret, and a regression test asserting `solr6`'s `existingConfigMap` secureComms override still works independently of the shared secret
- Chart version bumped to `1.9.0-alpha.0`

## Test plan

- [x] `helm unittest charts/alfresco-repository` — all 12 suites / 83 tests pass
- [x] `pre-commit run --all-files` — passes (helm-docs regenerated README)
- [x] manually verified the new regression test fails against a hardcoded-secureComms implementation and passes against the final one

OPSEXP-4226