### PR TITLE
OPSEXP-4208 Release 0.7.0 postgres

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   sure to deploy your own enterprise grade PostgreSQL instance and configure
   Alfresco charts to point to it.
 type: application
-version: 0.7.0-alpha.0
+version: 0.7.0
 appVersion: "17.9"
 dependencies:
   - name: alfresco-common

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -1,6 +1,6 @@
 # postgres
 
-![Version: 0.7.0-alpha.0](https://img.shields.io/badge/Version-0.7.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.9](https://img.shields.io/badge/AppVersion-17.9-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.9](https://img.shields.io/badge/AppVersion-17.9-informational?style=flat-square)
 
 WARNING: This chart is meant to ease initial deployment for TESTING purposes.
 DO NOT use this chart in any staging, or production environment. It has very


### PR DESCRIPTION
## Summary
Update postgres chart from 0.7.0-alpha.0 to 0.7.0 GA version.

The postgres chart can now be released as a GA version and then updated as a dependency in other charts that depend on it.

## Test plan
- [x] Chart validation passed (scripts/charts.sh)
- [ ] Release postgres chart
- [ ] Update postgres chart dependency in dependent charts

OPSEXP-4208