### PR TITLE
OPSEXP-4208 Fix updatecli test-deps pipeline to include alpha versions

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Updatecli
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatecli@v18.21.0
 
-      - run: updatecli apply
+      - run: updatecli pipeline apply
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -102,13 +102,13 @@ jobs:
           ref: ${{ inputs.alfresco-updatecli-ref || 'master' }}
           path: alfresco-updatecli
 
-      - name: updatecli apply
+      - name: updatecli pipeline apply
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
-          updatecli apply -c alfresco-updatecli/deployments/uber-manifest.tpl \
+          updatecli pipeline apply -c alfresco-updatecli/deployments/uber-manifest.tpl \
             -v alfresco-updatecli/deployments/values/supported-matrix.yaml \
             -v .github/updatecli-matrix-targets.yaml
 

--- a/test-deps.yaml
+++ b/test-deps.yaml
@@ -5,7 +5,7 @@ deps:
   postgresql:
     chart: postgres
     repository: https://alfresco.github.io/alfresco-helm-charts/
-    version: 0.6.0
+    version: 0.7.0-alpha.0
   activemq:
     chart: activemq
     repository: https://alfresco.github.io/alfresco-helm-charts/

--- a/test-deps.yaml
+++ b/test-deps.yaml
@@ -5,7 +5,7 @@ deps:
   postgresql:
     chart: postgres
     repository: https://alfresco.github.io/alfresco-helm-charts/
-    version: 0.7.0-alpha.0
+    version: 0.7.0
   activemq:
     chart: activemq
     repository: https://alfresco.github.io/alfresco-helm-charts/

--- a/updatecli.d/helm-autodiscovery.yaml
+++ b/updatecli.d/helm-autodiscovery.yaml
@@ -11,10 +11,3 @@ autodiscovery:
       versionfilter:
         kind: semver
         pattern: '>= 0.0.0-0'
-      ignore:
-        - dependencies:
-            # https://github.com/updatecli/updatecli/issues/1876
-            alfresco-insight-zeppelin: ""
-            common: ""
-            postgresql: ""
-            elasticsearch: ""

--- a/updatecli.d/helm-autodiscovery.yaml
+++ b/updatecli.d/helm-autodiscovery.yaml
@@ -4,11 +4,13 @@ name: "Helm autodiscovery for charts dependencies"
 autodiscovery:
   crawlers:
     helm:
-      # we have an alternate pipeline for image tags bumping
-      ignorecontainer: true
-      # Disable automatic chart version bump given that sometimes bump too much
-      # and we have chart testing checking against missed increments
+      # Increment manually because we have custom rules
       versionincrement: none
+      # Tags in values are handled separately via uber-manifest.tpl
+      ignorecontainer: true
+      versionfilter:
+        kind: semver
+        pattern: '>= 0.0.0-0'
       ignore:
         - dependencies:
             # https://github.com/updatecli/updatecli/issues/1876

--- a/updatecli.d/test-deps.yaml
+++ b/updatecli.d/test-deps.yaml
@@ -8,6 +8,9 @@ sources:
     spec:
       url: https://alfresco.github.io/alfresco-helm-charts/
       name: activemq
+      versionfilter:
+        kind: semver
+        pattern: '>= 0.0.0-0'
 
   postgres:
     name: "postgres"
@@ -15,6 +18,9 @@ sources:
     spec:
       url: https://alfresco.github.io/alfresco-helm-charts/
       name: postgres
+      versionfilter:
+        kind: semver
+        pattern: '>= 0.0.0-0'
 
   elastic:
     name: "elastic"
@@ -22,6 +28,9 @@ sources:
     spec:
       url: https://alfresco.github.io/alfresco-helm-charts/
       name: elastic
+      versionfilter:
+        kind: semver
+        pattern: '>= 0.0.0-0'
 
 targets:
   activemq:


### PR DESCRIPTION
Add versionfilter to updatecli configurations to allow pre-release versions (alpha, beta, rc) in test dependencies. This fixes the test-deps pipeline to properly include chart versions with pre-release tags.

Changes:
- Add semver versionfilter with pattern '>= 0.0.0-0' to helm-autodiscovery.yaml
- Add versionfilter to all sources in test-deps.yaml (activemq, postgres, elastic)
- Replace deprecated 'updatecli apply' with 'updatecli pipeline apply' in workflow

OPSEXP-4208