### PR TITLE
OPSEXP-4208 Release GA versions for alfresco-repository and alfresco-search-community

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.9.0-alpha.1
+version: 1.9.0
 appVersion: 26.2.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.9.0-alpha.1](https://img.shields.io/badge/Version-1.9.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 

--- a/charts/alfresco-search-community/Chart.yaml
+++ b/charts/alfresco-search-community/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-community
 description: A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 type: application
-version: 0.2.0-alpha.0
+version: 0.2.0
 appVersion: 5.7.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-community
 
-![Version: 0.2.0-alpha.0](https://img.shields.io/badge/Version-0.2.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
 
 A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 


### PR DESCRIPTION
Update charts to their GA versions:
- alfresco-repository: 1.9.0-alpha.0 → 1.9.0
- alfresco-search-community: 0.2.0-alpha.0 → 0.2.0

The alfresco-connector-hxi GA bump originally included in this PR is dropped since that chart has been replaced by alfresco-connector-cic on main, which starts its own pre-release version cycle.

Chart validation confirms no pre-release dependency violations after these updates.

## Test plan
- [x] Chart validation passed (scripts/charts.sh)

OPSEXP-4208