### PR TITLE
OPSEXP-4226 Fix Solr shared-secret regression for elasticsearch flavor

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.9.0-alpha.0
+version: 1.9.0-alpha.1
 appVersion: 26.2.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -114,7 +114,7 @@ The init container image is selected automatically based on the auth mode; overr
 | configuration.search.existingConfigMap.keys.url | string | `"SEARCH_URL"` | Key within the configmap  holding the search service URL. |
 | configuration.search.existingConfigMap.name | string | `nil` | Optional configmap containing the search service URL |
 | configuration.search.existingSecret.keys.password | string | `"ELASTICSEARCH_PASSWORD"` | Key within the secret holding the search service password |
-| configuration.search.existingSecret.keys.solr-secret | string | `"SOLR_SECRET"` | Key within the secret holding the legacy Solr tracking webscripts shared secret |
+| configuration.search.existingSecret.keys.solr-secret | string | `nil` | Key within the secret holding the legacy Solr tracking webscripts shared secret. Leave unset unless the existing secret genuinely carries this key. |
 | configuration.search.existingSecret.keys.username | string | `"ELASTICSEARCH_USERNAME"` | Key within the secret holding the search service username |
 | configuration.search.existingSecret.name | string | `nil` | Optional secret containing search service credentials |
 | configuration.search.flavor | string | `"noindex"` | Can be either `solr`, `elasticsearch` or `noindex` |

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.9.0-alpha.0](https://img.shields.io/badge/Version-1.9.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
+![Version: 1.9.0-alpha.1](https://img.shields.io/badge/Version-1.9.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 

--- a/charts/alfresco-repository/templates/_helpers-search.tpl
+++ b/charts/alfresco-repository/templates/_helpers-search.tpl
@@ -19,7 +19,7 @@ Usage: include "alfresco-repository.solr.security" (dict "search" (dict "existin
 
 */}}
 {{- define "alfresco-repository.solr.security" -}}
-{{- if .existingSecret.name }}
+{{- if and .existingSecret.name (index .existingSecret.keys "solr-secret") }}
   {{- print "secret" }}
 {{- else }}
   {{- not (empty (index . "solr-secret")) | ternary "secret" "none" }}
@@ -39,7 +39,7 @@ Usage: include "alfresco-repository.search.config" $
   -Dsolr.port="$SEARCH_PORT"
   -Dsolr.base.url="$SOLR_BASE_URL"
   -Dsolr.secureComms="$SEARCH_SECURECOMMS"
-  {{- if or .existingSecret.name (index . "solr-secret") }}
+  {{- if eq "secret" (include "alfresco-repository.solr.security" .) }}
   -Dsolr.sharedSecret=$SOLR_SECRET
   {{- end }}
   {{- else if eq "elasticsearch" (include "alfresco-repository.search.flavor.valid" .flavor) }}
@@ -51,7 +51,7 @@ Usage: include "alfresco-repository.search.config" $
   {{- range $key, $val := .elasticsearchProperties }}
   -Delasticsearch.{{ $key }}={{ $val }}
   {{- end }}
-  {{- if index . "solr-secret" }}
+  {{- if eq "secret" (include "alfresco-repository.solr.security" .) }}
   -Dsolr.secureComms="secret"
   -Dsolr.sharedSecret=$SOLR_SECRET
   {{- end }}

--- a/charts/alfresco-repository/templates/_helpers-search.tpl
+++ b/charts/alfresco-repository/templates/_helpers-search.tpl
@@ -19,8 +19,8 @@ Usage: include "alfresco-repository.solr.security" (dict "search" (dict "existin
 
 */}}
 {{- define "alfresco-repository.solr.security" -}}
-{{- if and .existingSecret.name (index .existingSecret.keys "solr-secret") }}
-  {{- print "secret" }}
+{{- if .existingSecret.name }}
+  {{- not (empty (index .existingSecret.keys "solr-secret")) | ternary "secret" "none" }}
 {{- else }}
   {{- not (empty (index . "solr-secret")) | ternary "secret" "none" }}
 {{- end }}

--- a/charts/alfresco-repository/templates/_helpers-search.tpl
+++ b/charts/alfresco-repository/templates/_helpers-search.tpl
@@ -51,7 +51,7 @@ Usage: include "alfresco-repository.search.config" $
   {{- range $key, $val := .elasticsearchProperties }}
   -Delasticsearch.{{ $key }}={{ $val }}
   {{- end }}
-  {{- if or .existingSecret.name (index . "solr-secret") }}
+  {{- if index . "solr-secret" }}
   -Dsolr.secureComms="secret"
   -Dsolr.sharedSecret=$SOLR_SECRET
   {{- end }}

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -151,6 +151,7 @@ spec:
           {{- $mqsecret := "" }}
           {{- $searchsecretCtx := dict }}
           {{- $searchsecret := "" }}
+          {{- $solrSecretKey := "" }}
           {{- with .Values.configuration }}
             {{- $dbsecretCtx = dict "Values" (dict "nameOverride" "secret-database") "Chart" $.Chart "Release" $.Release }}
             {{- $dbsecret = coalesce .db.existingSecret.name (include "alfresco-repository.fullname" $dbsecretCtx) }}
@@ -160,6 +161,7 @@ spec:
             {{- $mqsecret = coalesce .messageBroker.existingSecret.name (include "alfresco-repository.fullname" $mqsecretCtx) }}
             {{- $searchsecretCtx = dict "Values" (dict "nameOverride" "secret-search") "Chart" $.Chart "Release" $.Release }}
             {{- $searchsecret = coalesce .search.existingSecret.name (include "alfresco-repository.fullname" $searchsecretCtx) }}
+            {{- $solrSecretKey = ternary "SOLR_SECRET" (index .search.existingSecret.keys "solr-secret") (not .search.existingSecret.name) }}
           {{- end }}
           env:
             - name: ENC_METADATA_STOREPASS
@@ -197,12 +199,14 @@ spec:
                   name: {{ $searchsecret }}
                   key: {{ .Values.configuration.search.existingSecret.keys.password }}
                   optional: true
+            {{- if $solrSecretKey }}
             - name: SOLR_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $searchsecret }}
-                  key: {{ index .Values.configuration.search.existingSecret.keys "solr-secret" }}
+                  key: {{ $solrSecretKey }}
                   optional: true
+            {{- end }}
             - name: BROKER_URL
               valueFrom:
                 configMapKeyRef:

--- a/charts/alfresco-repository/tests/search_test.yaml
+++ b/charts/alfresco-repository/tests/search_test.yaml
@@ -341,6 +341,24 @@ tests:
             name: SOLR_SECRET
         template: deployment.yaml
 
+  - it: elasticsearch existingSecret without an explicit solr-secret key ignores a stray plaintext solr-secret value
+    set:
+      configuration:
+        search:
+          << : *esK8sResources
+          solr-secret: mysupersecret
+    asserts:
+      - notMatchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.(secureComms|sharedSecret)
+        template: configmap-repository.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOLR_SECRET
+        template: deployment.yaml
+
   - it: should render the legacy Solr shared secret alongside an ES flavor when explicitly configured via existingSecret
     set:
       configuration:

--- a/charts/alfresco-repository/tests/search_test.yaml
+++ b/charts/alfresco-repository/tests/search_test.yaml
@@ -296,6 +296,11 @@ tests:
                 key: PASS
                 optional: true
         template: deployment.yaml
+      - notMatchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.(secureComms|sharedSecret)
+        template: configmap-repository.yaml
 
   - it: Should default to noindex despite all other configs
     set: &messyconfig_all_noindex

--- a/charts/alfresco-repository/tests/search_test.yaml
+++ b/charts/alfresco-repository/tests/search_test.yaml
@@ -69,6 +69,16 @@ tests:
           pattern: |-
             (^\s*|[^\s]\s+)-Dsolr\.sharedSecret=\$SOLR_SECRET($|\s)
         template: configmap-repository.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOLR_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-secret-search
+                key: SOLR_SECRET
+                optional: true
+        template: deployment.yaml
 
   - it: should render a working Solr6 config based on values (noauth)
     set:
@@ -179,6 +189,30 @@ tests:
                 name: mysolrsecret
                 key: SOME_SECRET
                 optional: true
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.sharedSecret=\$SOLR_SECRET($|\s)
+        template: configmap-repository.yaml
+
+  - it: solr6 secureComms with existingSecret but no solr-secret key configured is not treated as a shared secret
+    set:
+      configuration:
+        search:
+          << : *solrK8sResources
+          existingSecret:
+            name: mysolrsecret
+    asserts:
+      - notMatchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.sharedSecret
+        template: configmap-repository.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOLR_SECRET
+        template: deployment.yaml
 
   - it: should render a working ES config based on values
     set:
@@ -301,6 +335,44 @@ tests:
           pattern: |-
             (^\s*|[^\s]\s+)-Dsolr\.(secureComms|sharedSecret)
         template: configmap-repository.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOLR_SECRET
+        template: deployment.yaml
+
+  - it: should render the legacy Solr shared secret alongside an ES flavor when explicitly configured via existingSecret
+    set:
+      configuration:
+        search:
+          << : *esK8sResources
+          existingSecret:
+            name: myessecret
+            keys:
+              username: USER
+              password: PASS
+              solr-secret: MY_SOLR_KEY
+    asserts:
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.secureComms="secret"($|\s)
+        template: configmap-repository.yaml
+      - matchRegex:
+          path: data.CATALINA_OPTS
+          pattern: |-
+            (^\s*|[^\s]\s+)-Dsolr\.sharedSecret=\$SOLR_SECRET($|\s)
+        template: configmap-repository.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOLR_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: myessecret
+                key: MY_SOLR_KEY
+                optional: true
+        template: deployment.yaml
 
   - it: Should default to noindex despite all other configs
     set: &messyconfig_all_noindex

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -138,8 +138,9 @@ configuration:
         # -- Key within the secret holding the search service password
         password: ELASTICSEARCH_PASSWORD
         # -- Key within the secret holding the legacy Solr tracking
-        # webscripts shared secret
-        solr-secret: SOLR_SECRET
+        # webscripts shared secret. Leave unset unless the existing secret
+        # genuinely carries this key.
+        solr-secret: null
 
     existingConfigMap:
       # -- Optional configmap containing the search service URL


### PR DESCRIPTION
## Summary

Commit f5cf99e4 (OPSEXP-4226, released as chart `alfresco-repository-1.9.0-alpha.0`) added a gate to the elasticsearch branch of `alfresco-repository.search.config` in `_helpers-search.tpl` that used `existingSecret.name` as a proxy for "a Solr shared secret is configured". That's wrong: `configuration.search.existingSecret` is a multi-purpose container commonly set purely to source `ELASTICSEARCH_USERNAME`/`ELASTICSEARCH_PASSWORD` for Elasticsearch auth, unrelated to the legacy Solr shared secret. Any elasticsearch-flavor deployment with `existingSecret.name` set for that reason alone (e.g. acs-deployment's hardcoded `alfresco-search-secret`) was forced into `solr.secureComms=secret` with an empty `$SOLR_SECRET`, failing repository startup with `Missing value for solr.sharedSecret configuration property`.

This PR gates that branch on the plaintext `solr-secret` value instead, the only unambiguous single-purpose signal available (there's no template-time way to peek inside an externally-referenced secret since the prior `lookup`-based check was intentionally removed in OPSEXP-2242 to keep `helm template`/dry-run working). The `solr6` branch and the `alfresco-repository.solr.security`/`alfresco-repository.solr.cm` helpers are untouched since they're only ever invoked for `flavor == solr6`, where `existingSecret` has no other legitimate purpose than carrying the Solr secret.

Also added a regression-locking test assertion (the existing "k8s existing resources" ES test case never asserted on `configmap-repository.yaml`'s `CATALINA_OPTS`, which is exactly the gap that let this ship), and bumped the chart to `1.9.0-alpha.1` since `1.9.0-alpha.0` was already released with the bug.

## Test plan

- [x] `helm unittest charts/alfresco-repository` — 83/83 tests passing, including the new regression assertion
- [x] `helm lint charts/alfresco-repository` — clean
- [x] `helm template` reproducing the acs-deployment scenario (ES flavor + `existingSecret.name` set, no `solr-secret`) confirmed `-Dsolr.secureComms`/`-Dsolr.sharedSecret` are no longer emitted
- [ ] Downstream: acs-deployment's `alfresco-repository` dependency needs bumping to this chart version once released

OPSEXP-4226