### PR TITLE
OPSEXP-4174 Move search-community shared secret from transform to repository config

### DIFF
--- a/charts/alfresco-search-community/Chart.yaml
+++ b/charts/alfresco-search-community/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-community
 description: A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 type: application
-version: 0.1.0
+version: 0.2.0-alpha.0
 appVersion: 5.7.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -68,7 +68,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | repository.existingConfigMap.name | string | `nil` | Alternatively, provide repository connection details via an existing configmap |
 | repository.sharedSecret.existingSecret.keys.sharedSecret | string | `"SOLR_SECRET"` | Key within the secret holding the shared secret |
 | repository.sharedSecret.existingSecret.name | string | `nil` | Alternatively, provide the shared secret via an existing secret |
-| repository.sharedSecret.value | string | `"notused"` | Shared secret authenticating the batch indexer against the repository's legacy Solr tracking webscripts API. Must match alfresco-repository's `configuration.search.solr-secret` |
+| repository.sharedSecret.value | string | `nil` | Shared secret authenticating the batch indexer against the repository's legacy Solr tracking webscripts API. Must match alfresco-repository's `configuration.search.solr-secret` |
 | repository.url | string | `nil` | URL of the Alfresco repository (ACS) |
 | resources.limits.cpu | string | `"2"` |  |
 | resources.limits.memory | string | `"2048Mi"` |  |

--- a/charts/alfresco-search-community/README.md
+++ b/charts/alfresco-search-community/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-community
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
+![Version: 0.2.0-alpha.0](https://img.shields.io/badge/Version-0.2.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
 
 A Helm chart for deploying the Alfresco Elasticsearch Community batch indexing component
 
@@ -66,6 +66,9 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | replicaCount | int | `1` | The batch indexing component is a singleton; this value must remain 1 (a second instance conflicts on the shared watermark and self-terminates) |
 | repository.existingConfigMap.keys.url | string | `"REPOSITORY_URL"` | Key within the configmap holding the full url to connect to the alfresco repository |
 | repository.existingConfigMap.name | string | `nil` | Alternatively, provide repository connection details via an existing configmap |
+| repository.sharedSecret.existingSecret.keys.sharedSecret | string | `"SOLR_SECRET"` | Key within the secret holding the shared secret |
+| repository.sharedSecret.existingSecret.name | string | `nil` | Alternatively, provide the shared secret via an existing secret |
+| repository.sharedSecret.value | string | `"notused"` | Shared secret authenticating the batch indexer against the repository's legacy Solr tracking webscripts API. Must match alfresco-repository's `configuration.search.solr-secret` |
 | repository.url | string | `nil` | URL of the Alfresco repository (ACS) |
 | resources.limits.cpu | string | `"2"` |  |
 | resources.limits.memory | string | `"2048Mi"` |  |
@@ -82,9 +85,6 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | tolerations | list | `[]` |  |
 | transform.existingConfigMap.keys.url | string | `"TRANSFORM_URL"` | Key within the configmap holding the URL of the transform config endpoint |
 | transform.existingConfigMap.name | string | `nil` | Alternatively, provide transform config endpoint details via an existing configmap |
-| transform.sharedSecret.existingSecret.keys.sharedSecret | string | `"ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET"` | Key within the secret holding the shared secret |
-| transform.sharedSecret.existingSecret.name | string | `nil` | Alternatively, provide the shared secret via an existing secret |
-| transform.sharedSecret.value | string | `"notused"` | Shared secret authenticating the accepted content media types cache query against the repository. Only used when that cache is enabled (disabled by default) |
 | transform.url | string | `"http://transform-core-aio:8090/transform/config"` | URL of the alfresco transform config endpoint. Only queried when the accepted content media types cache is enabled (disabled by default, see the environment section); a value is nonetheless required by the chart |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/alfresco-search-community/ci/default-values.yaml
+++ b/charts/alfresco-search-community/ci/default-values.yaml
@@ -8,10 +8,10 @@ db:
   password: alfresco
 repository:
   url: http://alfresco:8080
-transform:
-  url: http://transform-core-aio:8090/transform/config
   sharedSecret:
     value: secret
+transform:
+  url: http://transform-core-aio:8090/transform/config
 # The batch indexing component needs the Alfresco DB schema (created by the
 # repository) to become healthy, which is not available in chart-testing. Relax
 # the probes to a plain TCP check so the workload is validated as started.

--- a/charts/alfresco-search-community/templates/_helpers-config.tpl
+++ b/charts/alfresco-search-community/templates/_helpers-config.tpl
@@ -11,7 +11,7 @@ Usage: include "alfresco-search-community.config.env" $
 {{- $transformCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "transform")) "Chart" .Chart "Release" .Release }}
 {{- $transformCm := coalesce .Values.transform.existingConfigMap.name (include "alfresco-search-community.fullname" $transformCtx) }}
 {{- $secretCtx := dict "Values" (dict "nameOverride" (printf "%s-%s" (.Values.nameOverride | default .Chart.Name) "shared-secret")) "Chart" .Chart "Release" .Release }}
-{{- $sharedSecret := coalesce .Values.transform.sharedSecret.existingSecret.name (include "alfresco-search-community.fullname" $secretCtx) }}
+{{- $sharedSecret := coalesce .Values.repository.sharedSecret.existingSecret.name (include "alfresco-search-community.fullname" $secretCtx) }}
 - name: ELASTICSEARCH_INDEXNAME
   value: {{ .Values.indexName | quote }}
 - name: ALFRESCO_ACS_URL
@@ -28,5 +28,5 @@ Usage: include "alfresco-search-community.config.env" $
   valueFrom:
     secretKeyRef:
       name: {{ $sharedSecret }}
-      key: {{ .Values.transform.sharedSecret.existingSecret.keys.sharedSecret }}
+      key: {{ .Values.repository.sharedSecret.existingSecret.keys.sharedSecret }}
 {{- end -}}

--- a/charts/alfresco-search-community/templates/secret-shared-secret.yaml
+++ b/charts/alfresco-search-community/templates/secret-shared-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.transform.sharedSecret.existingSecret.name }}
+{{- if not .Values.repository.sharedSecret.existingSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +8,5 @@ metadata:
     {{- include "alfresco-search-community.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  {{ .Values.transform.sharedSecret.existingSecret.keys.sharedSecret }}: {{ required ".transform.sharedSecret.value is mandatory when not using existingSecret" .Values.transform.sharedSecret.value | b64enc | quote }}
+  {{ .Values.repository.sharedSecret.existingSecret.keys.sharedSecret }}: {{ required ".repository.sharedSecret.value is mandatory when not using existingSecret" .Values.repository.sharedSecret.value | b64enc | quote }}
 {{- end }}

--- a/charts/alfresco-search-community/tests/deployment_test.yaml
+++ b/charts/alfresco-search-community/tests/deployment_test.yaml
@@ -139,7 +139,7 @@ tests:
             name: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
             valueFrom:
               secretKeyRef:
-                key: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+                key: SOLR_SECRET
                 name: RELEASE-NAME-alfresco-search-community-shared-secret
   - it: should disable the accepted content media types cache by default
     asserts:
@@ -175,16 +175,16 @@ tests:
           name: repo-external-config
           keys:
             url: REPOSITORY_URL_EXTERNAL
-      transform:
-        existingConfigMap:
-          name: transform-external-config
-          keys:
-            url: TRANSFORM_URL_EXTERNAL
         sharedSecret:
           existingSecret:
             name: shared-secret-external
             keys:
               sharedSecret: SHARED_SECRET_EXTERNAL
+      transform:
+        existingConfigMap:
+          name: transform-external-config
+          keys:
+            url: TRANSFORM_URL_EXTERNAL
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/alfresco-search-community/tests/secret-shared-secret_test.yaml
+++ b/charts/alfresco-search-community/tests/secret-shared-secret_test.yaml
@@ -7,19 +7,19 @@ tests:
   - it: should base64 encode the provided shared secret
     asserts:
       - equal:
-          path: data.ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
+          path: data.SOLR_SECRET
           value: c2VjcmV0
   - it: should fail when shared secret value is missing
     set:
-      transform:
+      repository:
         sharedSecret:
           value: null
     asserts:
       - failedTemplate:
-          errorMessage: ".transform.sharedSecret.value is mandatory when not using existingSecret"
+          errorMessage: ".repository.sharedSecret.value is mandatory when not using existingSecret"
   - it: should not render when existingSecret is set
     set:
-      transform:
+      repository:
         sharedSecret:
           existingSecret:
             name: my-shared-secret

--- a/charts/alfresco-search-community/tests/values/embedded-charts-values.yaml
+++ b/charts/alfresco-search-community/tests/values/embedded-charts-values.yaml
@@ -6,7 +6,7 @@ db:
   password: alfresco
 repository:
   url: http://alfresco:8080
-transform:
-  url: http://transform-core-aio:8090/transform/config
   sharedSecret:
     value: secret
+transform:
+  url: http://transform-core-aio:8090/transform/config

--- a/charts/alfresco-search-community/values.yaml
+++ b/charts/alfresco-search-community/values.yaml
@@ -107,6 +107,17 @@ repository:
       # -- Key within the configmap holding the full url to connect to the
       # alfresco repository
       url: REPOSITORY_URL
+  sharedSecret:
+    # -- Shared secret authenticating the batch indexer against the
+    # repository's legacy Solr tracking webscripts API. Must match
+    # alfresco-repository's `configuration.search.solr-secret`
+    value: notused
+    existingSecret:
+      # -- Alternatively, provide the shared secret via an existing secret
+      name: null
+      keys:
+        # -- Key within the secret holding the shared secret
+        sharedSecret: SOLR_SECRET
 
 transform:
   # -- URL of the alfresco transform config endpoint. Only queried when the
@@ -121,17 +132,6 @@ transform:
       # -- Key within the configmap holding the URL of the transform config
       # endpoint
       url: TRANSFORM_URL
-  sharedSecret:
-    # -- Shared secret authenticating the accepted content media types cache
-    # query against the repository. Only used when that cache is enabled
-    # (disabled by default)
-    value: notused
-    existingSecret:
-      # -- Alternatively, provide the shared secret via an existing secret
-      name: null
-      keys:
-        # -- Key within the secret holding the shared secret
-        sharedSecret: ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/alfresco-search-community/values.yaml
+++ b/charts/alfresco-search-community/values.yaml
@@ -111,7 +111,7 @@ repository:
     # -- Shared secret authenticating the batch indexer against the
     # repository's legacy Solr tracking webscripts API. Must match
     # alfresco-repository's `configuration.search.solr-secret`
-    value: notused
+    value: null
     existingSecret:
       # -- Alternatively, provide the shared secret via an existing secret
       name: null


### PR DESCRIPTION
## Summary
The `sharedSecret` values section in the `alfresco-search-community` chart was originally placed under `transform`, on the assumption it related to the transform config endpoint. In reality it is the Solr shared secret used to authenticate the batch indexer against the repository's legacy Solr tracking webscripts API, the same secret historically used with Solr, so it belongs under `repository` instead. The chart is new, so this breaking change is released as a new alpha for the next minor version rather than requiring a migration path.

- Move `sharedSecret` (value, existingSecret name/keys) from `transform` to `repository` in `values.yaml`, `templates/_helpers-config.tpl`, and `templates/secret-shared-secret.yaml`
- Rename the default secret key from `ALFRESCO_CONTENT_TRANSFORM_SHAREDSECRET` to `SOLR_SECRET` and reword the value description to reference the legacy Solr tracking webscripts API and `alfresco-repository`'s `configuration.search.solr-secret`
- Bump chart version to `0.2.0-alpha.0`

## Test plan
- [x] `helm unittest charts/alfresco-search-community` (38/38 tests pass)
- [x] README regenerated via helm-docs to reflect `repository.sharedSecret.*`

OPSEXP-4174