### PR TITLE
OPSEXP-4187 Remove unused ats.transformUrl and cic.hxEnv from alfresco-connector-cic

### DIFF
--- a/charts/alfresco-connector-cic/Chart.yaml
+++ b/charts/alfresco-connector-cic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-connector-cic
 description: A Helm chart for deploying Alfresco connector cic services
 type: application
-version: 0.1.0-alpha.0
+version: 0.1.0-alpha.1
 appVersion: 1.0.1
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-connector-cic/README.md
+++ b/charts/alfresco-connector-cic/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-connector-cic
 
-![Version: 0.1.0-alpha.0](https://img.shields.io/badge/Version-0.1.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco connector cic services
 
@@ -23,10 +23,8 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` | Additional labels to be added to all resources (deployments, statefulsets, services, pods, etc.) Example:   Product: k8s   Environment: DEV |
 | ats.existingConfigMap.keys.sfsUrl | string | `"SFS_URL"` | Key within the configmap holding the URL of the alfresco shared filestore |
-| ats.existingConfigMap.keys.transformUrl | string | `"ATS_URL"` | Key within the configmap holding the URL of the alfresco transform |
 | ats.existingConfigMap.name | string | `nil` | Alternatively, provide ATS details via an existing configmap |
 | ats.sfsUrl | string | `nil` | URL of the alfresco shared filestore |
-| ats.transformUrl | string | `nil` | URL of the alfresco transform (trouter or tengine-aio) |
 | bulkIngester.affinity | object | `{}` |  |
 | bulkIngester.enabled | bool | `true` |  |
 | bulkIngester.environment.ALFRESCO_BULK_INGEST_PUBLISHER_ENDPOINT | string | `"activemq:queue:bulk-ingester-events"` |  |
@@ -58,7 +56,6 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | cic.hxAuthTokenUrl | string | `nil` |  |
 | cic.hxClientId | string | `nil` |  |
 | cic.hxClientSecret | string | `nil` |  |
-| cic.hxEnv | string | `nil` |  |
 | cic.hxEnvKey | string | `nil` |  |
 | cic.hxInsightIngestionUrl | string | `nil` |  |
 | cic.nucleusBaseUrl | string | `nil` | Nucleus connection settings (nucleus-sync only) |

--- a/charts/alfresco-connector-cic/docs/cic.yml
+++ b/charts/alfresco-connector-cic/docs/cic.yml
@@ -6,7 +6,6 @@ cic:
   hxClientSecret: your-client-secret
   hxEnvKey: alfresco-kd-ci-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx
   hxAppSourceId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx
-  hxEnv: staging
   # -- Nucleus connection settings (required for nucleus-sync)
   nucleusBaseUrl: "https://nucleus.experience.hyland.com"
   nucleusIdpBaseUrl: "https://auth.iam.staging.experience.hyland.com"

--- a/charts/alfresco-connector-cic/values.yaml
+++ b/charts/alfresco-connector-cic/values.yaml
@@ -276,16 +276,12 @@ repository:
       clientId: REPOSITORY_CLIENT_ID
       clientSecret: REPOSITORY_CLIENT_SECRET
 ats:
-  # -- URL of the alfresco transform (trouter or tengine-aio)
-  transformUrl: null
   # -- URL of the alfresco shared filestore
   sfsUrl: null
   existingConfigMap:
     # -- Alternatively, provide ATS details via an existing configmap
     name: null
     keys:
-      # -- Key within the configmap holding the URL of the alfresco transform
-      transformUrl: ATS_URL
       # -- Key within the configmap holding the URL of the alfresco shared filestore
       sfsUrl: SFS_URL
 cic:
@@ -295,7 +291,6 @@ cic:
   hxClientSecret: null
   hxEnvKey: null
   hxAppSourceId: null
-  hxEnv: null
   # -- Nucleus connection settings (nucleus-sync only)
   nucleusBaseUrl: null
   nucleusIdpBaseUrl: null


### PR DESCRIPTION
## Summary
- `ats.transformUrl` (`ATS_URL`) was copied from the `alfresco-search-enterprise` chart's ats pattern but no cic connector service (live-ingester, bulk-ingester, nucleus-sync) reads a transform-service URL — only `ats.sfsUrl`/`SFS_URL` is actually consumed
- `cic.hxEnv` has no matching configmap/secret key or env var mapping anywhere in the chart
- Both were dead configuration that looked functional in `values.yaml`, the generated README, and the tutorial doc (`docs/cic.yml`), removing them keeps the values schema an accurate reflection of what's actually configurable
- Bumped chart version to `0.1.0-alpha.1`

## Test plan
- [x] `helm lint .` passes
- [x] `helm template` renders successfully with required values set, and the rendered manifests contain no `ATS_URL` or `HX_ENV` references
- [x] `helm-docs` regenerated README with only the two dead rows removed

OPSEXP-4187