### PR TITLE
OPSEXP-4187: fix(alfresco-connector-cic): Align env vars with and external CM usage

### DIFF
--- a/charts/alfresco-connector-cic/Chart.yaml
+++ b/charts/alfresco-connector-cic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-connector-cic
 description: A Helm chart for deploying Alfresco connector cic services
 type: application
-version: 0.1.0-alpha.2
+version: 0.1.0-alpha.3
 appVersion: 1.0.1
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-connector-cic/README.md
+++ b/charts/alfresco-connector-cic/README.md
@@ -139,10 +139,10 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | repository.clientId | string | `nil` |  |
 | repository.clientSecret | string | `nil` |  |
 | repository.existingConfigMap.keys.apiUrl | string | `"REPOSITORY_API_BASE_URL"` | Key within the configmap holding the full Alfresco REST API v1 base url (used by nucleus-sync) |
-| repository.existingConfigMap.keys.authGrantType | string | `""` | Set to empty string to skip mounting this env var when using an external configmap |
-| repository.existingConfigMap.keys.authTokenUrl | string | `""` |  |
+| repository.existingConfigMap.keys.authGrantType | string | `"REPOSITORY_AUTH_GRANT_TYPE"` |  |
+| repository.existingConfigMap.keys.authTokenUrl | string | `"REPOSITORY_AUTH_TOKEN_URL"` |  |
 | repository.existingConfigMap.keys.url | string | `"REPOSITORY_URL"` | Key within the configmap holding the full url to connect to the alfresco repository |
-| repository.existingConfigMap.keys.versionOverride | string | `""` |  |
+| repository.existingConfigMap.keys.versionOverride | string | `"REPOSITORY_VERSION_OVERRIDE"` |  |
 | repository.existingConfigMap.name | string | `nil` | Alternatively, provide repository connection details via an existing configmap |
 | repository.existingSecret.keys.clientId | string | `"REPOSITORY_CLIENT_ID"` |  |
 | repository.existingSecret.keys.clientSecret | string | `"REPOSITORY_CLIENT_SECRET"` |  |

--- a/charts/alfresco-connector-cic/README.md
+++ b/charts/alfresco-connector-cic/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-connector-cic
 
-![Version: 0.1.0-alpha.2](https://img.shields.io/badge/Version-0.1.0--alpha.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.1.0-alpha.3](https://img.shields.io/badge/Version-0.1.0--alpha.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco connector cic services
 
@@ -80,6 +80,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | liveIngester.environment.ALFRESCO_BULKINGESTER_ENDPOINT | string | `"activemq:queue:bulk-ingester-events"` |  |
 | liveIngester.environment.ALFRESCO_BULKINGESTER_MAXIMUMREDELIVERIES | string | `"6"` |  |
 | liveIngester.environment.ALFRESCO_BULKINGESTER_REDELIVERYDELAYMS | string | `"1000"` |  |
+| liveIngester.environment.AUTH_PROVIDERS_HYLANDEXPERIENCE_GRANTTYPE | string | `"client_credentials"` |  |
 | liveIngester.environment.CAMEL_COMPONENT_ACTIVEMQ_TRANSACTED | string | `"true"` |  |
 | liveIngester.environment.SERVER_PORT | int | `8080` |  |
 | liveIngester.image.internalPort | int | `8080` |  |
@@ -112,6 +113,7 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | nucleusSync.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0] | object | `{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["{{ template \"alfresco-connector-cic.name\" $ }}"]},{"key":"app.kubernetes.io/instance","operator":"In","values":["{{ $.Release.Name }}"]},{"key":"app.kubernetes.io/component","operator":"In","values":["{{ $.Chart.Name }}"]}]},"topologyKey":"topology.kubernetes.io/zone"},"weight":10}` | Prefer to schedule the content pod on a different zone |
 | nucleusSync.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[1] | object | `{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["{{ template \"alfresco-connector-cic.name\" $ }}"]},{"key":"app.kubernetes.io/instance","operator":"In","values":["{{ $.Release.Name }}"]},{"key":"app.kubernetes.io/component","operator":"In","values":["{{ $.Chart.Name }}"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":5}` | Prefer to schedule the content pod on a different node |
 | nucleusSync.enabled | bool | `true` |  |
+| nucleusSync.environment.AUTH_ALFRESCO_TYPE | string | `"basic"` |  |
 | nucleusSync.environment.AUTH_HX_TYPE | string | `"oauth2"` |  |
 | nucleusSync.environment.SERVER_PORT | int | `8080` |  |
 | nucleusSync.image.internalPort | int | `8080` |  |
@@ -137,11 +139,10 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | repository.clientId | string | `nil` |  |
 | repository.clientSecret | string | `nil` |  |
 | repository.existingConfigMap.keys.apiUrl | string | `"REPOSITORY_API_BASE_URL"` | Key within the configmap holding the full Alfresco REST API v1 base url (used by nucleus-sync) |
-| repository.existingConfigMap.keys.authGrantType | string | `"REPOSITORY_AUTH_GRANT_TYPE"` |  |
-| repository.existingConfigMap.keys.authTokenUrl | string | `"REPOSITORY_AUTH_TOKEN_URL"` |  |
-| repository.existingConfigMap.keys.authType | string | `"REPOSITORY_AUTH_TYPE"` |  |
+| repository.existingConfigMap.keys.authGrantType | string | `""` | Set to empty string to skip mounting this env var when using an external configmap |
+| repository.existingConfigMap.keys.authTokenUrl | string | `""` |  |
 | repository.existingConfigMap.keys.url | string | `"REPOSITORY_URL"` | Key within the configmap holding the full url to connect to the alfresco repository |
-| repository.existingConfigMap.keys.versionOverride | string | `"REPOSITORY_VERSION_OVERRIDE"` |  |
+| repository.existingConfigMap.keys.versionOverride | string | `""` |  |
 | repository.existingConfigMap.name | string | `nil` | Alternatively, provide repository connection details via an existing configmap |
 | repository.existingSecret.keys.clientId | string | `"REPOSITORY_CLIENT_ID"` |  |
 | repository.existingSecret.keys.clientSecret | string | `"REPOSITORY_CLIENT_SECRET"` |  |

--- a/charts/alfresco-connector-cic/templates/_helpers-env-repository.tpl
+++ b/charts/alfresco-connector-cic/templates/_helpers-env-repository.tpl
@@ -11,21 +11,21 @@ Usage: include "alfresco-connector-cic.repository.cm.env" $
     configMapKeyRef:
         name: {{ $cmName }}
         key: {{ .existingConfigMap.keys.url }}
-{{- if .existingConfigMap.keys.authGrantType }}
+{{- if and .existingConfigMap.keys.authGrantType .authGrantType }}
 - name: AUTH_PROVIDERS_ALFRESCO_GRANTTYPE
   valueFrom:
     configMapKeyRef:
       name: {{ $cmName }}
       key: {{ .existingConfigMap.keys.authGrantType }}
 {{- end }}
-{{- if .existingConfigMap.keys.authTokenUrl }}
+{{- if and .existingConfigMap.keys.authTokenUrl .authTokenUrl }}
 - name: AUTH_PROVIDERS_ALFRESCO_TOKENURI
   valueFrom:
     configMapKeyRef:
       name: {{ $cmName }}
       key: {{ .existingConfigMap.keys.authTokenUrl }}
 {{- end }}
-{{- if .existingConfigMap.keys.versionOverride }}
+{{- if and .existingConfigMap.keys.versionOverride .versionOverride }}
 - name: ALFRESCO_REPOSITORY_VERSIONOVERRIDE
   valueFrom:
     configMapKeyRef:

--- a/charts/alfresco-connector-cic/templates/_helpers-env-repository.tpl
+++ b/charts/alfresco-connector-cic/templates/_helpers-env-repository.tpl
@@ -11,13 +11,6 @@ Usage: include "alfresco-connector-cic.repository.cm.env" $
     configMapKeyRef:
         name: {{ $cmName }}
         key: {{ .existingConfigMap.keys.url }}
-{{- if .existingConfigMap.keys.authType }}
-- name: AUTH_PROVIDERS_ALFRESCO_TYPE
-  valueFrom:
-    configMapKeyRef:
-      name: {{ $cmName }}
-      key: {{ .existingConfigMap.keys.authType }}
-{{- end }}
 {{- if .existingConfigMap.keys.authGrantType }}
 - name: AUTH_PROVIDERS_ALFRESCO_GRANTTYPE
   valueFrom:
@@ -55,13 +48,6 @@ Usage: include "alfresco-connector-cic.nucleus-sync.repository.cm.env" $
     configMapKeyRef:
         name: {{ $cmName }}
         key: {{ .existingConfigMap.keys.apiUrl }}
-{{- if .existingConfigMap.keys.authType }}
-- name: AUTH_ALFRESCO_TYPE
-  valueFrom:
-    configMapKeyRef:
-      name: {{ $cmName }}
-      key: {{ .existingConfigMap.keys.authType }}
-{{- end }}
 {{- end -}}
 {{- end -}}
 
@@ -104,6 +90,7 @@ Usage: include "alfresco-connector-cic.repository.secret.env" $
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ .existingSecret.keys.password }}
+{{- if ne (.authType | default "basic") "basic" }}
 - name: AUTH_PROVIDERS_ALFRESCO_CLIENTID
   valueFrom:
     secretKeyRef:
@@ -114,5 +101,6 @@ Usage: include "alfresco-connector-cic.repository.secret.env" $
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ .existingSecret.keys.clientSecret }}
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/alfresco-connector-cic/tests/deployment_test.yaml
+++ b/charts/alfresco-connector-cic/tests/deployment_test.yaml
@@ -155,11 +155,6 @@ tests:
           content:
             name: AUTH_PROVIDERS_ALFRESCO_USERNAME
           any: true
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: AUTH_PROVIDERS_ALFRESCO_TYPE
-          any: true
       # HX auth — live-ingester uses full AUTH_PROVIDERS_HYLANDEXPERIENCE_* names
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/alfresco-connector-cic/tests/deployment_test.yaml
+++ b/charts/alfresco-connector-cic/tests/deployment_test.yaml
@@ -155,7 +155,7 @@ tests:
           content:
             name: AUTH_PROVIDERS_ALFRESCO_USERNAME
           any: true
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].env
           content:
             name: AUTH_PROVIDERS_ALFRESCO_TYPE

--- a/charts/alfresco-connector-cic/values.yaml
+++ b/charts/alfresco-connector-cic/values.yaml
@@ -37,6 +37,7 @@ liveIngester:
     ALFRESCO_BULKINGESTER_MAXIMUMREDELIVERIES: "6"
     ALFRESCO_BULKINGESTER_REDELIVERYDELAYMS: "1000"
     CAMEL_COMPONENT_ACTIVEMQ_TRANSACTED: "true"
+    AUTH_PROVIDERS_HYLANDEXPERIENCE_GRANTTYPE: client_credentials
   livenessProbe:
     initialDelaySeconds: 30
     httpGet:
@@ -140,6 +141,7 @@ nucleusSync:
   environment:
     SERVER_PORT: 8080
     AUTH_HX_TYPE: oauth2
+    AUTH_ALFRESCO_TYPE: basic
   livenessProbe:
     initialDelaySeconds: 30
     httpGet:
@@ -260,10 +262,10 @@ repository:
       # -- Key within the configmap holding the full Alfresco REST API v1 base
       # url (used by nucleus-sync)
       apiUrl: REPOSITORY_API_BASE_URL
-      authType: REPOSITORY_AUTH_TYPE
-      authGrantType: REPOSITORY_AUTH_GRANT_TYPE
-      authTokenUrl: REPOSITORY_AUTH_TOKEN_URL
-      versionOverride: REPOSITORY_VERSION_OVERRIDE
+      # -- Set to empty string to skip mounting this env var when using an external configmap
+      authGrantType: ""
+      authTokenUrl: ""
+      versionOverride: ""
   existingSecret:
     name: null
     keys:

--- a/charts/alfresco-connector-cic/values.yaml
+++ b/charts/alfresco-connector-cic/values.yaml
@@ -262,10 +262,9 @@ repository:
       # -- Key within the configmap holding the full Alfresco REST API v1 base
       # url (used by nucleus-sync)
       apiUrl: REPOSITORY_API_BASE_URL
-      # -- Set to empty string to skip mounting this env var when using an external configmap
-      authGrantType: ""
-      authTokenUrl: ""
-      versionOverride: ""
+      authGrantType: REPOSITORY_AUTH_GRANT_TYPE
+      authTokenUrl: REPOSITORY_AUTH_TOKEN_URL
+      versionOverride: REPOSITORY_VERSION_OVERRIDE
   existingSecret:
     name: null
     keys:


### PR DESCRIPTION
OPSEXP-4187
## Changes

- Move `AUTH_ALFRESCO_TYPE` to `nucleusSync.environment` — removes ConfigMap dependency
- Add missing `AUTH_PROVIDERS_HYLANDEXPERIENCE_GRANTTYPE: client_credentials`
  to `liveIngester.environment`