### PR TITLE
OPSEXP-4289 mount sized /dev/shm volume to prevent shared memory exhaustion

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   sure to deploy your own enterprise grade PostgreSQL instance and configure
   Alfresco charts to point to it.
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "17.9"
 dependencies:
   - name: alfresco-common

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -56,7 +56,8 @@ Alfresco charts to point to it.
 | primary.service.annotations | object | `{}` |  |
 | primary.service.name | string | `"postgresql"` | used for naming pvc |
 | primary.service.ports.postgresql | int | `5432` |  |
-| primary.shmVolume | object | `{"enabled":true,"sizeLimit":"1Gi"}` | Memory-backed volume mounted at /dev/shm for PostgreSQL dynamic shared memory (parallel queries). The container runtime default of 64Mi is too small for heavy workloads and causes "could not resize shared memory segment ... No space left on device". Counts against the pod memory limit, so keep sizeLimit comfortably below primary.resources.limits.memory. |
+| primary.shmVolume.enabled | bool | `true` |  |
+| primary.shmVolume.sizeLimit | string | `"256Mi"` | Size of the memory-backed /dev/shm volume for PostgreSQL dynamic shared memory (parallel queries). The container runtime default of 64Mi is too small for heavy workloads and causes "could not resize shared memory segment ... No space left on device". Charged to the pod memory cgroup, so keep it comfortably below primary.resources.limits.memory. |
 | readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | readinessProbe.exec.command[1] | string | `"-c"` |  |
 | readinessProbe.exec.command[2] | string | `"-e"` |  |

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -1,6 +1,6 @@
 # postgres
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.9](https://img.shields.io/badge/AppVersion-17.9-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.9](https://img.shields.io/badge/AppVersion-17.9-informational?style=flat-square)
 
 WARNING: This chart is meant to ease initial deployment for TESTING purposes.
 DO NOT use this chart in any staging, or production environment. It has very
@@ -56,6 +56,7 @@ Alfresco charts to point to it.
 | primary.service.annotations | object | `{}` |  |
 | primary.service.name | string | `"postgresql"` | used for naming pvc |
 | primary.service.ports.postgresql | int | `5432` |  |
+| primary.shmVolume | object | `{"enabled":true,"sizeLimit":"1Gi"}` | Memory-backed volume mounted at /dev/shm for PostgreSQL dynamic shared memory (parallel queries). The container runtime default of 64Mi is too small for heavy workloads and causes "could not resize shared memory segment ... No space left on device". Counts against the pod memory limit, so keep sizeLimit comfortably below primary.resources.limits.memory. |
 | readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | readinessProbe.exec.command[1] | string | `"-c"` |  |
 | readinessProbe.exec.command[2] | string | `"-e"` |  |

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -65,6 +65,16 @@ spec:
             - name: data
               mountPath: {{ .primary.persistence.data.mountPath }}
               subPath: {{ .primary.persistence.data.subPath }}
+            {{- if .primary.shmVolume.enabled }}
+            - name: dshm
+              mountPath: /dev/shm
+            {{- end }}
       volumes:
         {{- include "alfresco-common.data_volume" .primary | nindent 8 }}
+        {{- if .primary.shmVolume.enabled }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .primary.shmVolume.sizeLimit | quote }}
+        {{- end }}
 {{- end }}

--- a/charts/postgres/tests/statefulset_test.yaml
+++ b/charts/postgres/tests/statefulset_test.yaml
@@ -54,7 +54,7 @@ tests:
             name: dshm
             emptyDir:
               medium: Memory
-              sizeLimit: 1Gi
+              sizeLimit: 256Mi
 
   - it: should honour a custom shmVolume.sizeLimit
     set:
@@ -87,4 +87,4 @@ tests:
             name: dshm
             emptyDir:
               medium: Memory
-              sizeLimit: 1Gi
+              sizeLimit: 256Mi

--- a/charts/postgres/tests/statefulset_test.yaml
+++ b/charts/postgres/tests/statefulset_test.yaml
@@ -39,3 +39,52 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].mountPath
           value: /custom/path
+
+  - it: should mount a memory-backed /dev/shm volume by default
+    set: {}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: dshm
+            mountPath: /dev/shm
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 1Gi
+
+  - it: should honour a custom shmVolume.sizeLimit
+    set:
+      primary:
+        shmVolume:
+          sizeLimit: 2Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 2Gi
+
+  - it: should not render the /dev/shm volume when shmVolume is disabled
+    set:
+      primary:
+        shmVolume:
+          enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: dshm
+            mountPath: /dev/shm
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 1Gi

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -47,6 +47,14 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 3
 primary:
+  # -- Memory-backed volume mounted at /dev/shm for PostgreSQL dynamic shared
+  # memory (parallel queries). The container runtime default of 64Mi is too
+  # small for heavy workloads and causes "could not resize shared memory
+  # segment ... No space left on device". Counts against the pod memory limit,
+  # so keep sizeLimit comfortably below primary.resources.limits.memory.
+  shmVolume:
+    enabled: true
+    sizeLimit: 1Gi
   extendedConfiguration: |
     max_connections=250
     shared_buffers=512MB

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -47,14 +47,14 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 3
 primary:
-  # -- Memory-backed volume mounted at /dev/shm for PostgreSQL dynamic shared
-  # memory (parallel queries). The container runtime default of 64Mi is too
-  # small for heavy workloads and causes "could not resize shared memory
-  # segment ... No space left on device". Counts against the pod memory limit,
-  # so keep sizeLimit comfortably below primary.resources.limits.memory.
   shmVolume:
     enabled: true
-    sizeLimit: 1Gi
+    # -- Size of the memory-backed /dev/shm volume for PostgreSQL dynamic shared
+    # memory (parallel queries). The container runtime default of 64Mi is too
+    # small for heavy workloads and causes "could not resize shared memory
+    # segment ... No space left on device". Charged to the pod memory cgroup, so
+    # keep it comfortably below primary.resources.limits.memory.
+    sizeLimit: 256Mi
   extendedConfiguration: |
     max_connections=250
     shared_buffers=512MB


### PR DESCRIPTION
## What

Add a configurable, memory-backed `/dev/shm` volume to the `postgres` chart, enabled by default (`primary.shmVolume`, `sizeLimit: 256Mi`), mounted at `/dev/shm` on the PostgreSQL container.

## Why

PostgreSQL uses POSIX dynamic shared memory (`dynamic_shared_memory_type = posix`, the default in PG 17) for parallel query execution and related operations, allocating those segments under `/dev/shm`. In a container `/dev/shm` defaults to the runtime's 64Mi tmpfs, and the chart's StatefulSet previously mounted no shm volume, so the pod ran with that 64Mi cap. Under heavier workloads — notably the ACS repository data-population job — parallel operations exhaust the 64Mi and PostgreSQL aborts with `could not resize shared memory segment ... No space left on device`, causing intermittent failures (OPSEXP-4289).

Consumers had no way to fix this from values: the chart exposed no shm/volume knob, so the only workarounds were to redirect DSM off tmpfs (`dynamic_shared_memory_type = mmap`, which trades the fast tmpfs path for disk-backed memory-mapped files) or to disable parallelism. Both are downstream band-aids. Giving PostgreSQL a right-sized `/dev/shm` fixes it at the source and keeps the faster `posix` path.

## How

The volume is a standard `emptyDir` with `medium: Memory` and a configurable `sizeLimit`, mounted at `/dev/shm`, both guarded by `primary.shmVolume.enabled`. The default 256Mi is a conservative starting point — 4x the 64Mi container default, enough to clear the observed exhaustion while sitting well below the container's existing 8Gi memory limit. A memory-backed emptyDir is charged to the pod's memory cgroup, so `sizeLimit` should stay comfortably under `primary.resources.limits.memory` and can be raised for heavier workloads. On Kubernetes with `SizeMemoryBackedVolumes` (GA), the `sizeLimit` is enforced against the tmpfs itself rather than defaulting to half of node RAM. `sizeLimit` is tunable, and the whole volume can be disabled for callers that manage shm externally.

## Testing

`helm unittest` covers the new behaviour: the volume and mount render by default, a custom `sizeLimit` propagates, and nothing renders when `shmVolume.enabled: false`. Full suite passes (8/8). `README.md` regenerated via helm-docs; chart bumped `0.7.0` → `0.8.0`.

## Rollout note

The umbrella `alfresco-content-services` chart must bump its `postgres` subchart dependency to `0.8.0` to pick this up. Downstream `mmap` workarounds can then be retired so environments regain the faster `posix` DSM path.

OPSEXP-4289
