### PR TITLE
OPSEXP-4187: Remove tcpSocket probe overrides

### DIFF
--- a/charts/alfresco-connector-cic/Chart.yaml
+++ b/charts/alfresco-connector-cic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-connector-cic
 description: A Helm chart for deploying Alfresco connector cic services
 type: application
-version: 0.1.0-alpha.3
+version: 0.1.0-alpha.4
 appVersion: 1.0.1
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-connector-cic/README.md
+++ b/charts/alfresco-connector-cic/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-connector-cic
 
-![Version: 0.1.0-alpha.3](https://img.shields.io/badge/Version-0.1.0--alpha.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.1.0-alpha.4](https://img.shields.io/badge/Version-0.1.0--alpha.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco connector cic services
 

--- a/charts/alfresco-connector-cic/ci/default-values.yaml
+++ b/charts/alfresco-connector-cic/ci/default-values.yaml
@@ -1,6 +1,7 @@
-# No repository is deployed for CI. The endpoint below returns HTTP < 400, so
-# AcsHealthProbe starts the Camel routes. bulk-ingester is disabled because it
-# requires a real repository.
+# No real Alfresco Repository is deployed for this chart's tests. The endpoint
+# below returns HTTP < 400, so AcsHealthProbe can start the live-ingester and
+# nucleus-sync Camel routes. bulk-ingester's wait-for-repository init container
+# (which requires a real repository) is disabled.
 liveIngester:
   replicaCount: 1
   resources:

--- a/charts/alfresco-connector-cic/ci/default-values.yaml
+++ b/charts/alfresco-connector-cic/ci/default-values.yaml
@@ -1,10 +1,6 @@
-# No real Alfresco Repository is deployed for this chart's tests. Readiness
-# normally depends on reaching the repository (Camel routes only start after
-# an "acsHealthy" event), but setting repository.url (env ALFRESCO_REPOSITORY_BASEURL)
-# and repository.versionOverride (env ALFRESCO_REPOSITORY_VERSIONOVERRIDE) below
-# fakes that health check, so the default httpGet probes can be used as-is
-# here without a real repository. bulk-ingester's wait-for-repository init
-# container (which blocks on an HTTP 200 from the repository) is disabled.
+# No repository is deployed for CI. The endpoint below returns HTTP < 400, so
+# AcsHealthProbe starts the Camel routes. bulk-ingester is disabled because it
+# requires a real repository.
 liveIngester:
   replicaCount: 1
   resources:
@@ -35,7 +31,7 @@ messageBroker:
   username: admin
   password: admin
 repository:
-  url: http://repository
+  url: https://alfresco.example.com
   username: admin
   password: admin
   versionOverride: '23.3.0'

--- a/charts/alfresco-connector-cic/ci/default-values.yaml
+++ b/charts/alfresco-connector-cic/ci/default-values.yaml
@@ -32,10 +32,10 @@ messageBroker:
   username: admin
   password: admin
 repository:
-  url: https://alfresco.example.com
+  url: https://alfresco.github.io/alfresco-helm-charts/test/alfresco/service/devicesync/config
   username: admin
   password: admin
-  versionOverride: '23.3.0'
+  versionOverride: "23.3.0"
 ats:
   sfsUrl: http://alfresco-transform-services-sfs
 cic:

--- a/charts/alfresco-connector-cic/ci/default-values.yaml
+++ b/charts/alfresco-connector-cic/ci/default-values.yaml
@@ -1,7 +1,7 @@
 # No real Alfresco Repository is deployed for this chart's tests. Readiness
 # normally depends on reaching the repository (Camel routes only start after
-# an "acsHealthy" event), but setting repository.url (alfresco.repository.base-url)
-# and repository.versionOverride (ALFRESCO_REPOSITORY_VERSIONOVERRIDE) below
+# an "acsHealthy" event), but setting repository.url (env ALFRESCO_REPOSITORY_BASEURL)
+# and repository.versionOverride (env ALFRESCO_REPOSITORY_VERSIONOVERRIDE) below
 # fakes that health check, so the default httpGet probes can be used as-is
 # here without a real repository. bulk-ingester's wait-for-repository init
 # container (which blocks on an HTTP 200 from the repository) is disabled.

--- a/charts/alfresco-connector-cic/ci/default-values.yaml
+++ b/charts/alfresco-connector-cic/ci/default-values.yaml
@@ -1,7 +1,10 @@
-# No real Alfresco Repository is deployed for this chart's tests, so
-# live-ingester/nucleus-sync readiness (which depends on reaching it) is
-# relaxed to a plain TCP check, and bulk-ingester's wait-for-repository init
-# container (which blocks on an HTTP 200 from it) is disabled.
+# No real Alfresco Repository is deployed for this chart's tests. Readiness
+# normally depends on reaching the repository (Camel routes only start after
+# an "acsHealthy" event), but setting repository.url (alfresco.repository.base-url)
+# and repository.versionOverride (ALFRESCO_REPOSITORY_VERSIONOVERRIDE) below
+# fakes that health check, so the default httpGet probes can be used as-is
+# here without a real repository. bulk-ingester's wait-for-repository init
+# container (which blocks on an HTTP 200 from the repository) is disabled.
 liveIngester:
   replicaCount: 1
   resources:
@@ -11,18 +14,6 @@ liveIngester:
     limits:
       cpu: "1"
       memory: "500Mi"
-  livenessProbe:
-    httpGet: null
-    tcpSocket:
-      port: 8080
-    initialDelaySeconds: 60
-    periodSeconds: 30
-  readinessProbe:
-    httpGet: null
-    tcpSocket:
-      port: 8080
-    initialDelaySeconds: 30
-    periodSeconds: 30
 bulkIngester:
   enabled: false
 nucleusSync:
@@ -35,18 +26,6 @@ nucleusSync:
     limits:
       cpu: "1"
       memory: "1Gi"
-  livenessProbe:
-    httpGet: null
-    tcpSocket:
-      port: 8080
-    initialDelaySeconds: 60
-    periodSeconds: 30
-  readinessProbe:
-    httpGet: null
-    tcpSocket:
-      port: 8080
-    initialDelaySeconds: 30
-    periodSeconds: 30
 db:
   url: jdbc:postgresql://postgresql:5432/alfresco
   username: alfresco

--- a/charts/alfresco-connector-cic/ci/default-values.yaml
+++ b/charts/alfresco-connector-cic/ci/default-values.yaml
@@ -1,7 +1,7 @@
-# No real Alfresco Repository is deployed for this chart's tests. The endpoint
-# below returns HTTP < 400, so AcsHealthProbe can start the live-ingester and
-# nucleus-sync Camel routes. bulk-ingester's wait-for-repository init container
-# (which requires a real repository) is disabled.
+# No real Alfresco Repository is deployed for this chart's tests.
+# The repository URL below returns HTTP < 400, so AcsHealthProbe can start the
+# live-ingester and nucleus-sync Camel routes. bulk-ingester's
+# wait-for-repository init container, which requires a real repository, is disabled.
 liveIngester:
   replicaCount: 1
   resources:


### PR DESCRIPTION
OPSEXP-4187
## Summary
Removes the `tcpSocket` liveness/readiness probe override for `liveIngester`
and `nucleusSync` in `charts/alfresco-connector-cic/ci/default-values.yaml`,
so chart-testing's KinD install job (`ct install --wait`) now exercises the
chart's real `httpGet` probes (`/actuator/health/liveness`,
`/actuator/health/readiness`) instead of a plain TCP port check.

## Chart changes
- `ci/default-values.yaml`: removed `tcpSocket` probe overrides for
  `liveIngester`/`nucleusSync`; 
- `Chart.yaml`: version bump `0.1.0-alpha.3` → `0.1.0-alpha.4`
- `README.md`: regenerated via `helm-docs`

## Repository mock configuration

No Alfresco Repository is deployed in this chart's CI environment. The CI
values use:

```yaml
repository:
  url: https://alfresco.github.io/alfresco-helm-charts/test/alfresco/service/devicesync/config
  versionOverride: "23.3.0"