### PR TITLE
OPSEXP-4240: fix(alfresco-search-enterprise): wait for Elasticsearch health before reindexing

### DIFF
--- a/charts/alfresco-search-enterprise/Chart.yaml
+++ b/charts/alfresco-search-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: alfresco-search-enterprise
 description: A Helm chart for deploying Alfresco Elasticsearch connector
 type: application
-version: 5.2.0
+version: 5.3.0-alpha.0
 appVersion: 5.7.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -111,11 +111,15 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | reindexing.image.pullPolicy | string | `"IfNotPresent"` |  |
 | reindexing.image.repository | string | `"quay.io/alfresco/alfresco-elasticsearch-reindexing"` |  |
 | reindexing.image.tag | string | `"5.7.0"` |  |
-| reindexing.initcontainers.waitForElasticsearch.image.pullPolicy | string | `"IfNotPresent"` |  |
-| reindexing.initcontainers.waitForElasticsearch.image.repository | string | `"curlimages/curl"` |  |
-| reindexing.initcontainers.waitForElasticsearch.image.tag | string | `"8.11.0"` |  |
-| reindexing.initcontainers.waitForElasticsearch.resources.limits.cpu | string | `"250m"` |  |
-| reindexing.initcontainers.waitForElasticsearch.resources.limits.memory | string | `"20Mi"` |  |
+| reindexing.initcontainers.waitForElasticsearch.auth.aws.region | string | `nil` | AWS region of the OpenSearch domain; required when mode is `iam` |
+| reindexing.initcontainers.waitForElasticsearch.auth.aws.service | string | `"es"` | AWS service name for SigV4 signing (defaults to `es` for managed OpenSearch/Elasticsearch) |
+| reindexing.initcontainers.waitForElasticsearch.auth.mode | string | `"basic"` | Authentication mode for the health-check request: `basic` (HTTP basic auth) or `iam` (AWS SigV4, signed with the pod's AWS identity via IRSA) |
+| reindexing.initcontainers.waitForElasticsearch.enabled | bool | `false` | Wait for Elasticsearch cluster health before starting reindexing. Disabled by default. Only the first URI in `SPRING_ELASTICSEARCH_REST_URIS` is checked. |
+| reindexing.initcontainers.waitForElasticsearch.images | object | `{"basic":{"pullPolicy":"IfNotPresent","repository":"curlimages/curl","tag":"8.11.0"},"iam":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/okigan/awscurl","tag":"v0.44"}}` | Init container image per auth mode; the entry matching `auth.mode` is used |
+| reindexing.initcontainers.waitForElasticsearch.resources.basic.limits.cpu | string | `"250m"` |  |
+| reindexing.initcontainers.waitForElasticsearch.resources.basic.limits.memory | string | `"20Mi"` |  |
+| reindexing.initcontainers.waitForElasticsearch.resources.iam.limits.cpu | string | `"250m"` |  |
+| reindexing.initcontainers.waitForElasticsearch.resources.iam.limits.memory | string | `"256Mi"` |  |
 | reindexing.initcontainers.waitForRepository.image.pullPolicy | string | `"IfNotPresent"` |  |
 | reindexing.initcontainers.waitForRepository.image.repository | string | `"curlimages/curl"` |  |
 | reindexing.initcontainers.waitForRepository.image.tag | string | `"8.11.0"` |  |

--- a/charts/alfresco-search-enterprise/README.md
+++ b/charts/alfresco-search-enterprise/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-search-enterprise
 
-![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
+![Version: 5.3.0-alpha.0](https://img.shields.io/badge/Version-5.3.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.7.0](https://img.shields.io/badge/AppVersion-5.7.0-informational?style=flat-square)
 
 A Helm chart for deploying Alfresco Elasticsearch connector
 
@@ -111,6 +111,11 @@ Checkout [alfresco-content-services chart's doc](https://github.com/Alfresco/acs
 | reindexing.image.pullPolicy | string | `"IfNotPresent"` |  |
 | reindexing.image.repository | string | `"quay.io/alfresco/alfresco-elasticsearch-reindexing"` |  |
 | reindexing.image.tag | string | `"5.7.0"` |  |
+| reindexing.initcontainers.waitForElasticsearch.image.pullPolicy | string | `"IfNotPresent"` |  |
+| reindexing.initcontainers.waitForElasticsearch.image.repository | string | `"curlimages/curl"` |  |
+| reindexing.initcontainers.waitForElasticsearch.image.tag | string | `"8.11.0"` |  |
+| reindexing.initcontainers.waitForElasticsearch.resources.limits.cpu | string | `"250m"` |  |
+| reindexing.initcontainers.waitForElasticsearch.resources.limits.memory | string | `"20Mi"` |  |
 | reindexing.initcontainers.waitForRepository.image.pullPolicy | string | `"IfNotPresent"` |  |
 | reindexing.initcontainers.waitForRepository.image.repository | string | `"curlimages/curl"` |  |
 | reindexing.initcontainers.waitForRepository.image.tag | string | `"8.11.0"` |  |

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -120,7 +120,7 @@ spec:
           # Only start reindexing once Elasticsearch reports a healthy cluster status
           args:
             - |
-              until curl -sf -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
+              until curl -sf --connect-timeout 5 --max-time 10 -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
                 "${SPRING_ELASTICSEARCH_REST_URIS}/_cluster/health?wait_for_status=yellow&timeout=5s" -o /dev/null
               do
                 echo "Waiting for Elasticsearch to become healthy at ${SPRING_ELASTICSEARCH_REST_URIS} ..."

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -125,13 +125,10 @@ spec:
             {{- include "alfresco-search-enterprise.config.spring.envCredentials" $ | nindent 12 }}
             {{- end }}
           command: ["/bin/sh", "-c"]
-          # Only start reindexing once Elasticsearch reports a healthy cluster status.
-          # Only the first URI is checked when multiple are configured, matching
-          # alfresco-repository's initContainers.createIndexTemplate pattern.
           args:
             - |
               ES_URL="${SPRING_ELASTICSEARCH_REST_URIS%%,*}"
-              check_cluster_health() {
+              until
               {{- if $iam }}
                 awscurl \
                   --fail-with-body \
@@ -145,8 +142,6 @@ spec:
                   -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
               {{- end }}
                   "${ES_URL}/_cluster/health?wait_for_status=yellow&timeout=5s"
-              }
-              until check_cluster_health
               do
                 echo "Waiting for Elasticsearch to become healthy at ${ES_URL} ..."
                 sleep 5

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -106,27 +106,54 @@ spec:
               done
               echo 'Alfresco is ready, delay reindexing to give a chance to fully initialise.'
               sleep 30
+        {{- if .Values.reindexing.initcontainers.waitForElasticsearch.enabled }}
+        {{- with .Values.reindexing.initcontainers.waitForElasticsearch }}
+        {{- $mode := (.auth.mode | default "basic") }}
+        {{- if not (has $mode (list "basic" "iam")) }}
+        {{- fail (printf "reindexing.initcontainers.waitForElasticsearch.auth.mode must be \"basic\" or \"iam\", got %q" $mode) }}
+        {{- end }}
+        {{- $iam := eq $mode "iam" }}
         - name: wait-for-elasticsearch
-          {{- with .Values.reindexing.initcontainers.waitForElasticsearch }}
-          image: {{ printf "%s:%s" .image.repository .image.tag | quote }}
-          imagePullPolicy: {{ .image.pullPolicy }}
-          resources: {{- toYaml .resources | nindent 12 }}
-          {{- end }}
-          {{- include "alfresco-common.component-security-context" .Values | indent 8 }}
+          {{- $image := index .images $mode }}
+          image: {{ printf "%s:%s" $image.repository $image.tag | quote }}
+          imagePullPolicy: {{ $image.pullPolicy }}
+          resources: {{- toYaml (index .resources $mode) | nindent 12 }}
+          {{- include "alfresco-common.component-security-context" $.Values | indent 8 }}
           env:
             {{- include "alfresco-search-enterprise.config.spring.es.env" $ | nindent 12 }}
-            {{- include "alfresco-search-enterprise.config.spring.envCredentials" . | nindent 12 }}
+            {{- if not $iam }}
+            {{- include "alfresco-search-enterprise.config.spring.envCredentials" $ | nindent 12 }}
+            {{- end }}
           command: ["/bin/sh", "-c"]
-          # Only start reindexing once Elasticsearch reports a healthy cluster status
+          # Only start reindexing once Elasticsearch reports a healthy cluster status.
+          # Only the first URI is checked when multiple are configured, matching
+          # alfresco-repository's initContainers.createIndexTemplate pattern.
           args:
             - |
-              until curl -sf --connect-timeout 5 --max-time 10 -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
-                "${SPRING_ELASTICSEARCH_REST_URIS}/_cluster/health?wait_for_status=yellow&timeout=5s" -o /dev/null
+              ES_URL="${SPRING_ELASTICSEARCH_REST_URIS%%,*}"
+              check_cluster_health() {
+              {{- if $iam }}
+                awscurl \
+                  --fail-with-body \
+                  -o /dev/null \
+                  --service {{ .auth.aws.service | quote }} \
+                  --region {{ required "reindexing.initcontainers.waitForElasticsearch.auth.aws.region is required when auth.mode is iam" .auth.aws.region | quote }} \
+              {{- else }}
+                curl \
+                  -sf --connect-timeout 5 --max-time 10 \
+                  -o /dev/null \
+                  -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
+              {{- end }}
+                  "${ES_URL}/_cluster/health?wait_for_status=yellow&timeout=5s"
+              }
+              until check_cluster_health
               do
-                echo "Waiting for Elasticsearch to become healthy at ${SPRING_ELASTICSEARCH_REST_URIS} ..."
+                echo "Waiting for Elasticsearch to become healthy at ${ES_URL} ..."
                 sleep 5
               done
               echo 'Elasticsearch is healthy, reindexing started!'
+        {{- end }}
+        {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
+++ b/charts/alfresco-search-enterprise/templates/reindexing-job.yaml
@@ -106,7 +106,27 @@ spec:
               done
               echo 'Alfresco is ready, delay reindexing to give a chance to fully initialise.'
               sleep 30
-              echo 'Reindexing started!'
+        - name: wait-for-elasticsearch
+          {{- with .Values.reindexing.initcontainers.waitForElasticsearch }}
+          image: {{ printf "%s:%s" .image.repository .image.tag | quote }}
+          imagePullPolicy: {{ .image.pullPolicy }}
+          resources: {{- toYaml .resources | nindent 12 }}
+          {{- end }}
+          {{- include "alfresco-common.component-security-context" .Values | indent 8 }}
+          env:
+            {{- include "alfresco-search-enterprise.config.spring.es.env" $ | nindent 12 }}
+            {{- include "alfresco-search-enterprise.config.spring.envCredentials" . | nindent 12 }}
+          command: ["/bin/sh", "-c"]
+          # Only start reindexing once Elasticsearch reports a healthy cluster status
+          args:
+            - |
+              until curl -sf -u "${SPRING_ELASTICSEARCH_REST_USERNAME}:${SPRING_ELASTICSEARCH_REST_PASSWORD}" \
+                "${SPRING_ELASTICSEARCH_REST_URIS}/_cluster/health?wait_for_status=yellow&timeout=5s" -o /dev/null
+              do
+                echo "Waiting for Elasticsearch to become healthy at ${SPRING_ELASTICSEARCH_REST_URIS} ..."
+                sleep 5
+              done
+              echo 'Elasticsearch is healthy, reindexing started!'
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
+++ b/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
@@ -170,7 +170,18 @@ tests:
                 name: mycm
                 key: REPO_URL
 
-  - it: should render wait-for-elasticsearch init container waiting on cluster health
+  - it: should not render wait-for-elasticsearch init container by default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-repository
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+
+  - it: should render wait-for-elasticsearch init container waiting on cluster health when enabled
+    set:
+      reindexing.initcontainers.waitForElasticsearch.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.initContainers[1].name
@@ -208,6 +219,56 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[1].args[0]
           pattern: "--connect-timeout 5 --max-time 10"
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: 'ES_URL="\$\{SPRING_ELASTICSEARCH_REST_URIS%%,\*\}"'
+
+  - it: should render wait-for-elasticsearch with awscurl when auth mode is iam
+    set:
+      reindexing.initcontainers.waitForElasticsearch:
+        enabled: true
+        auth:
+          mode: iam
+          aws:
+            region: eu-west-1
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].image
+          pattern: "ghcr.io/okigan/awscurl:.+"
+      - notContains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_USERNAME
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: "awscurl \\\\"
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: "--region \"eu-west-1\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: "--service \"es\""
+
+  - it: should fail when auth mode is iam without a region
+    set:
+      reindexing.initcontainers.waitForElasticsearch:
+        enabled: true
+        auth:
+          mode: iam
+    asserts:
+      - failedTemplate:
+          errorMessage: reindexing.initcontainers.waitForElasticsearch.auth.aws.region is required when auth.mode is iam
+
+  - it: should fail when auth mode is invalid
+    set:
+      reindexing.initcontainers.waitForElasticsearch:
+        enabled: true
+        auth:
+          mode: invalid
+    asserts:
+      - failedTemplate:
+          errorMessage: 'reindexing.initcontainers.waitForElasticsearch.auth.mode must be "basic" or "iam", got "invalid"'
+
 
   - it: has default hook annotation
     asserts:

--- a/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
+++ b/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
@@ -170,6 +170,34 @@ tests:
                 name: mycm
                 key: REPO_URL
 
+  - it: should render wait-for-elasticsearch init container waiting on cluster health
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-elasticsearch
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].image
+          pattern: "curlimages/curl:.+"
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_URIS
+            valueFrom:
+              configMapKeyRef:
+                name: RELEASE-NAME-alfresco-search-enterprise-es
+                key: SEARCH_URL
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-alfresco-search-enterprise-es
+                key: SEARCH_USERNAME
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: _cluster/health\?wait_for_status=yellow
+
   - it: has default hook annotation
     asserts:
       - equal:

--- a/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
+++ b/charts/alfresco-search-enterprise/tests/reindexing-job_test.yaml
@@ -194,9 +194,20 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-alfresco-search-enterprise-es
                 key: SEARCH_USERNAME
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: SPRING_ELASTICSEARCH_REST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-alfresco-search-enterprise-es
+                key: SEARCH_PASSWORD
       - matchRegex:
           path: spec.template.spec.initContainers[1].args[0]
           pattern: _cluster/health\?wait_for_status=yellow
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: "--connect-timeout 5 --max-time 10"
 
   - it: has default hook annotation
     asserts:

--- a/charts/alfresco-search-enterprise/values.yaml
+++ b/charts/alfresco-search-enterprise/values.yaml
@@ -291,6 +291,15 @@ reindexing:
         limits:
           cpu: "250m"
           memory: "20Mi"
+    waitForElasticsearch:
+      image:
+        repository: curlimages/curl
+        tag: "8.11.0"
+        pullPolicy: IfNotPresent
+      resources:
+        limits:
+          cpu: "250m"
+          memory: "20Mi"
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/alfresco-search-enterprise/values.yaml
+++ b/charts/alfresco-search-enterprise/values.yaml
@@ -292,14 +292,35 @@ reindexing:
           cpu: "250m"
           memory: "20Mi"
     waitForElasticsearch:
-      image:
-        repository: curlimages/curl
-        tag: "8.11.0"
-        pullPolicy: IfNotPresent
+      # -- Wait for Elasticsearch cluster health before starting reindexing. Disabled by default. Only the first URI in `SPRING_ELASTICSEARCH_REST_URIS` is checked.
+      enabled: false
+      auth:
+        # -- Authentication mode for the health-check request: `basic` (HTTP basic auth) or `iam` (AWS SigV4, signed with the pod's AWS identity via IRSA)
+        mode: basic
+        aws:
+          # -- AWS region of the OpenSearch domain; required when mode is `iam`
+          region: null
+          # -- AWS service name for SigV4 signing (defaults to `es` for managed OpenSearch/Elasticsearch)
+          service: es
+      # -- Init container image per auth mode; the entry matching `auth.mode` is used
+      images:
+        basic:
+          repository: curlimages/curl
+          tag: "8.11.0"
+          pullPolicy: IfNotPresent
+        iam:
+          repository: ghcr.io/okigan/awscurl
+          tag: "v0.44"
+          pullPolicy: IfNotPresent
       resources:
-        limits:
-          cpu: "250m"
-          memory: "20Mi"
+        basic:
+          limits:
+            cpu: "250m"
+            memory: "20Mi"
+        iam:
+          limits:
+            cpu: "250m"
+            memory: "256Mi"
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
OPSEXP-4240

Ensure Search Enterprise reindexing starts only after Elasticsearch is healthy. Previously, the job waited for Repository readiness but could begin while Elasticsearch was unavailable, resulting in failed/incomplete indexing that Kubernetes incorrectly reported as successful and causing downstream Newman/DTAS search failures.
refer: https://github.com/Alfresco/acs-deployment/actions/runs/32458048808/job/96710487403#step:17:902

Add a `wait-for-elasticsearch` init container  that polls
`_cluster/health?wait_for_status=yellow` using the existing
SPRING_ELASTICSEARCH_* connection/credentials env vars, before the
reindexing container runs.

- Add `reindexing.initcontainers.waitForElasticsearch` values (image,
  resources) mirroring `waitForRepository`.
- Add unit test coverage for the new init container.
- Bump chart version to 5.3.0-alpha.0.

