### PR TITLE
OPSEXP-4240 alfresco-repository: add dynamic mapping setting to index template

### DIFF
--- a/charts/alfresco-repository/Chart.yaml
+++ b/charts/alfresco-repository/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: alfresco-repository
 description: Alfresco content repository Helm chart
 type: application
-version: 1.9.0
+version: 1.10.0-alpha.0
 appVersion: 26.2.0
 dependencies:
   - name: alfresco-common

--- a/charts/alfresco-repository/README.md
+++ b/charts/alfresco-repository/README.md
@@ -5,7 +5,7 @@ parent: Charts Reference
 
 # alfresco-repository
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
+![Version: 1.10.0-alpha.0](https://img.shields.io/badge/Version-1.10.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2.0](https://img.shields.io/badge/AppVersion-26.2.0-informational?style=flat-square)
 
 Alfresco content repository Helm chart
 
@@ -158,6 +158,7 @@ The init container image is selected automatically based on the auth mode; overr
 | initContainers.createIndexTemplate.auth.aws.region | string | `nil` | AWS region of the OpenSearch domain; required when mode is `iam` |
 | initContainers.createIndexTemplate.auth.aws.service | string | `"es"` | AWS service name for SigV4 signing (defaults to `es` for managed OpenSearch/Elasticsearch) |
 | initContainers.createIndexTemplate.auth.mode | string | `"basic"` | Authentication mode for the index-template request: `basic` (HTTP basic auth) or `iam` (AWS SigV4, signed with the pod's AWS identity via IRSA) |
+| initContainers.createIndexTemplate.dynamic | bool | `false` | Whether new fields are added dynamically to the index mapping. Disable to avoid unbounded index growth from unexpected fields. |
 | initContainers.createIndexTemplate.enabled | bool | `false` | Whether to create an Elasticsearch index template before starting the repository |
 | initContainers.createIndexTemplate.images | object | `{"basic":{"pullPolicy":"IfNotPresent","repository":"curlimages/curl","tag":"8.11.0"},"iam":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/okigan/awscurl","tag":"v0.44"}}` | Init container image per auth mode; the entry matching `auth.mode` is used |
 | initContainers.createIndexTemplate.indexName | string | `"alfresco"` | Index name to apply the template to |

--- a/charts/alfresco-repository/templates/deployment.yaml
+++ b/charts/alfresco-repository/templates/deployment.yaml
@@ -123,6 +123,9 @@ spec:
                             }
                           }
                         }
+                      },
+                      "mappings": {
+                        "dynamic": {{ .dynamic }}
                       }
                     }
                   }'

--- a/charts/alfresco-repository/tests/create-index-template_test.yaml
+++ b/charts/alfresco-repository/tests/create-index-template_test.yaml
@@ -162,6 +162,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[1].args[0]
           pattern: '.*"limit": 7500.*'
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: '.*"dynamic": false.*'
 
   - it: should use init container overrides for max_result_window and totalFieldsLimit
     set:
@@ -180,6 +183,17 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[1].args[0]
           pattern: '.*"limit": 12000.*'
+
+  - it: should use configured dynamic mapping setting
+    set:
+      initContainers:
+        createIndexTemplate:
+          enabled: true
+          dynamic: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: '.*"dynamic": true.*'
 
   - it: should include elasticsearch credentials from search configuration
     set:

--- a/charts/alfresco-repository/values.yaml
+++ b/charts/alfresco-repository/values.yaml
@@ -409,6 +409,8 @@ initContainers:
     numberOfShards: 1
     # -- Number of replicas for the index
     numberOfReplicas: 0
+    # -- Whether new fields are added dynamically to the index mapping. Disable to avoid unbounded index growth from unexpected fields.
+    dynamic: false
 global:
   # -- If a private image registry a secret can be defined and passed to
   # kubernetes, see:


### PR DESCRIPTION
## Summary
- Elasticsearch defaults `mappings.dynamic` to `true`, letting unrecognized fields get added to the index mapping automatically, which can lead to index/mapping bloat in production. Expose `initContainers.createIndexTemplate.dynamic` (default `false`) so the init container's index template disables this unless explicitly opted back in. As per [official docs](https://docs.hyland.com/r/Alfresco/Alfresco-Search-Enterprise/4.1/Alfresco-Search-Enterprise/Administer/Pre-indexing-considerations/Mapping).
- Bumped chart version to `1.10.0-alpha.0` and regenerated the README via `helm-docs`.

## Test plan
- [x] `helm unittest charts/alfresco-repository` — 87/87 tests pass, including two new assertions for the default (`dynamic: false`) and an override (`dynamic: true`)
- [x] `helm-docs` regenerated README with the new value documented

OPSEXP-4240